### PR TITLE
feat(client): queue background chat streams

### DIFF
--- a/apps/client/app/components/AppSidebar/ThreadsList.tsx
+++ b/apps/client/app/components/AppSidebar/ThreadsList.tsx
@@ -1,17 +1,19 @@
 import { useState, useEffect, useCallback, useTransition } from 'react';
 import { NavLink, useNavigate, useParams } from 'react-router';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { CheckIcon, PencilIcon, TrashIcon, XIcon } from 'lucide-react';
+import { AlertCircleIcon, CheckIcon, Clock3Icon, PencilIcon, TrashIcon, XIcon } from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 
 import type { Route } from '@/react-router/types/root';
 import {
   IThreads,
+  clearThreadChatErrorAtom,
   enqueuePersistence,
   replaceMessagesAtom,
   threadAtom,
-  threadLoadingAtom,
+  threadChatErrorsAtom,
+  threadChatStateAtom,
   threadsRefreshAtom,
 } from '@/store';
 import {
@@ -51,7 +53,9 @@ const ThreadsList = () => {
   const [isPending, startTransition] = useTransition();
   const params = useParams<Route.ClientLoaderArgs['params']>();
   const threadsRefresh = useAtomValue(threadsRefreshAtom);
-  const isChatLoading = useAtomValue(threadLoadingAtom);
+  const threadChatState = useAtomValue(threadChatStateAtom);
+  const threadChatErrors = useAtomValue(threadChatErrorsAtom);
+  const clearThreadChatError = useSetAtom(clearThreadChatErrorAtom);
   const navigate = useNavigate();
 
   const { open, setOpenMobile } = useSidebar();
@@ -76,6 +80,11 @@ const ThreadsList = () => {
 
   const deleteChats = useCallback(
     async (threadId: string) => {
+      if (Object.keys(threadChatState).length) {
+        toast.info('Stop or cancel queued work before deleting chats.');
+        return;
+      }
+
       const { remainingMessages, nextThreads } = await enqueuePersistence(async () => {
         const [messages, storedThreads] = await Promise.all([getMessages(), getThreads()]);
         const remainingMessages = { ...(messages || {}) };
@@ -105,7 +114,7 @@ const ThreadsList = () => {
 
       fetchThreads();
     },
-    [fetchThreads, navigate, params.threadId, replaceMessages, setOpenMobile, setThread]
+    [fetchThreads, navigate, params.threadId, replaceMessages, setOpenMobile, setThread, threadChatState]
   );
 
   const renameThread = useCallback(async () => {
@@ -160,6 +169,8 @@ const ThreadsList = () => {
                 ))
               : threads.map(({ id, metadata: { name, timestamp } }) => {
                   const isSelected = id === params.threadId;
+                  const activity = threadChatState[id];
+                  const error = threadChatErrors[id];
 
                   return (
                     <ContextMenu key={id}>
@@ -212,12 +223,7 @@ const ThreadsList = () => {
                                     return;
                                   }
 
-                                  if (isChatLoading) {
-                                    ev.preventDefault();
-                                    toast.info('Stop generating before switching chats.');
-                                    return;
-                                  }
-
+                                  clearThreadChatError(id);
                                   setOpenMobile(false);
                                 }}
                                 preventScrollReset
@@ -238,11 +244,28 @@ const ThreadsList = () => {
                                     className="absolute inset-y-1.5 left-0 w-1 rounded-full bg-sidebar-primary"
                                   />
                                 )}
-                                <p
-                                  className="min-w-0 flex-1 truncate text-left"
-                                  title={name || format(new Date(timestamp), 'hh:mm A - DD/MM/YY')}>
-                                  {name || format(new Date(timestamp), 'hh:mm A - DD/MM/YY')}
-                                </p>
+                                <span className="flex min-w-0 flex-1 items-center gap-2">
+                                  {activity?.state === 'streaming' && (
+                                    <span
+                                      aria-label="Generating response"
+                                      className="size-1.5 shrink-0 rounded-full bg-sidebar-primary motion-safe:animate-pulse"
+                                    />
+                                  )}
+                                  {activity?.state === 'queued' && (
+                                    <Clock3Icon
+                                      aria-label={`Queued, position ${activity.position}`}
+                                      className="size-3.5 shrink-0 text-sidebar-primary"
+                                    />
+                                  )}
+                                  {!activity && error && (
+                                    <AlertCircleIcon aria-label="Response failed" className="size-3.5 shrink-0 text-destructive" />
+                                  )}
+                                  <p
+                                    className="min-w-0 flex-1 truncate text-left"
+                                    title={name || format(new Date(timestamp), 'hh:mm A - DD/MM/YY')}>
+                                    {name || format(new Date(timestamp), 'hh:mm A - DD/MM/YY')}
+                                  </p>
+                                </span>
                               </NavLink>
                             </SidebarMenuButton>
                           )}
@@ -262,11 +285,6 @@ const ThreadsList = () => {
                               </Button>
                               <DeleteAlert
                                 onDelete={() => {
-                                  if (isChatLoading) {
-                                    toast.info('Stop generating before switching chats.');
-                                    return;
-                                  }
-
                                   void deleteChats(id);
                                 }}>
                                 <Button
@@ -294,11 +312,6 @@ const ThreadsList = () => {
                         <ContextMenuItem
                           variant="destructive"
                           onSelect={() => {
-                            if (isChatLoading) {
-                              toast.info('Stop generating before switching chats.');
-                              return;
-                            }
-
                             setThreadToDelete(id);
                           }}>
                           <TrashIcon />
@@ -315,7 +328,7 @@ const ThreadsList = () => {
               if (!open) setThreadToDelete(null);
             }}
             onDelete={() => {
-              if (threadToDelete && !isChatLoading) void deleteChats(threadToDelete);
+              if (threadToDelete) void deleteChats(threadToDelete);
               setThreadToDelete(null);
             }}
           />

--- a/apps/client/app/components/AppSidebar/ThreadsList.tsx
+++ b/apps/client/app/components/AppSidebar/ThreadsList.tsx
@@ -10,13 +10,16 @@ import {
   IThreads,
   clearThreadChatErrorAtom,
   enqueuePersistence,
+  removeThreadMessagesAtom,
   replaceMessagesAtom,
   threadAtom,
   threadChatErrorsAtom,
   threadChatStateAtom,
   threadsRefreshAtom,
+  workspaceReadyAtom,
 } from '@/store';
 import {
+  getActiveWorkspaceAccount,
   getMessages,
   getThreads,
   setMessages,
@@ -55,33 +58,43 @@ const ThreadsList = () => {
   const threadsRefresh = useAtomValue(threadsRefreshAtom);
   const threadChatState = useAtomValue(threadChatStateAtom);
   const threadChatErrors = useAtomValue(threadChatErrorsAtom);
+  const workspaceReady = useAtomValue(workspaceReadyAtom);
   const clearThreadChatError = useSetAtom(clearThreadChatErrorAtom);
+  const removeThreadMessages = useSetAtom(removeThreadMessagesAtom);
   const navigate = useNavigate();
 
   const { open, setOpenMobile } = useSidebar();
 
   const fetchThreads = useCallback(() => {
+    const accountId = getActiveWorkspaceAccount();
     startTransition(async () => {
       const newThreads = await getThreads();
-      setThreads(newThreads || []);
+      if (getActiveWorkspaceAccount() === accountId) {
+        setThreads(newThreads || []);
+      }
     });
   }, []);
 
   useEffect(() => {
+    if (!workspaceReady) {
+      setThreads([]);
+      return;
+    }
+
     fetchThreads();
-  }, [thread, threadsRefresh]);
+  }, [fetchThreads, thread, threadsRefresh, workspaceReady]);
 
   useEffect(() => {
     // Refetch threads when sidebar opens
-    if (open) {
+    if (open && workspaceReady) {
       fetchThreads();
     }
-  }, [open, fetchThreads]);
+  }, [open, fetchThreads, workspaceReady]);
 
   const deleteChats = useCallback(
     async (threadId: string) => {
-      if (Object.keys(threadChatState).length) {
-        toast.info('Stop or cancel queued work before deleting chats.');
+      if (threadChatState[threadId]) {
+        toast.info('Stop or cancel this chat before deleting it.');
         return;
       }
 
@@ -95,6 +108,9 @@ const ThreadsList = () => {
 
         return { remainingMessages, nextThreads };
       });
+
+      removeThreadMessages(threadId);
+      clearThreadChatError(threadId);
 
       if (params.threadId === threadId) {
         const nextThread = nextThreads[0];
@@ -114,7 +130,17 @@ const ThreadsList = () => {
 
       fetchThreads();
     },
-    [fetchThreads, navigate, params.threadId, replaceMessages, setOpenMobile, setThread, threadChatState]
+    [
+      clearThreadChatError,
+      fetchThreads,
+      navigate,
+      params.threadId,
+      removeThreadMessages,
+      replaceMessages,
+      setOpenMobile,
+      setThread,
+      threadChatState,
+    ]
   );
 
   const renameThread = useCallback(async () => {

--- a/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
+++ b/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
@@ -21,6 +21,8 @@ import { languages, supportedTextModels, profiles } from 'utils';
 
 import {
   configAtom,
+  activeChatJobAtom,
+  clearThreadMessagesAtom,
   defaultConfig,
   getDefaultThread,
   replaceMessagesAtom,
@@ -28,10 +30,12 @@ import {
   updateThreadSettingsAtom,
   waitForPersistence,
   refreshThreadsAtom,
+  queuedChatJobsAtom,
   userSettingsScrollTargetAtom,
   type IThreadSettings,
 } from '@/store';
 import { clearLocalData, deleteAllChats, getUserSettings, setUserSettings } from '@/utils/lforage';
+import { abortAllStreams } from '@/utils/chat-stream-registry';
 import {
   createVault,
   hasVault,
@@ -120,6 +124,9 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
   const activeThread = useAtomValue(threadAtom);
   const setThread = useSetAtom(threadAtom);
   const replaceMessages = useSetAtom(replaceMessagesAtom);
+  const setActiveChatJob = useSetAtom(activeChatJobAtom);
+  const setQueuedChatJobs = useSetAtom(queuedChatJobsAtom);
+  const clearThreadMessages = useSetAtom(clearThreadMessagesAtom);
   const refreshThreads = useSetAtom(refreshThreadsAtom);
   const updateActiveThreadSettings = useSetAtom(updateThreadSettingsAtom);
   const customInstructionsRef = useRef<HTMLElement>(null);
@@ -233,6 +240,10 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
   };
 
   const handleDeleteAllChats = async () => {
+    abortAllStreams();
+    setActiveChatJob(null);
+    setQueuedChatJobs([]);
+    clearThreadMessages();
     await deleteAllChats();
     setThread(getDefaultThread((await getUserSettings()) || undefined));
     replaceMessages([]);
@@ -244,6 +255,10 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
   };
 
   const handleResetAllData = async () => {
+    abortAllStreams();
+    setActiveChatJob(null);
+    setQueuedChatJobs([]);
+    clearThreadMessages();
     await clearLocalData();
     if (user?.id) await resetVault(user.id);
     setConfig(defaultConfig);

--- a/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
+++ b/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
@@ -21,7 +21,6 @@ import { languages, supportedTextModels, profiles } from 'utils';
 
 import {
   configAtom,
-  activeChatJobAtom,
   clearThreadMessagesAtom,
   defaultConfig,
   getDefaultThread,
@@ -30,7 +29,7 @@ import {
   updateThreadSettingsAtom,
   waitForPersistence,
   refreshThreadsAtom,
-  queuedChatJobsAtom,
+  resetChatQueueAtom,
   userSettingsScrollTargetAtom,
   type IThreadSettings,
 } from '@/store';
@@ -124,8 +123,7 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
   const activeThread = useAtomValue(threadAtom);
   const setThread = useSetAtom(threadAtom);
   const replaceMessages = useSetAtom(replaceMessagesAtom);
-  const setActiveChatJob = useSetAtom(activeChatJobAtom);
-  const setQueuedChatJobs = useSetAtom(queuedChatJobsAtom);
+  const resetChatQueue = useSetAtom(resetChatQueueAtom);
   const clearThreadMessages = useSetAtom(clearThreadMessagesAtom);
   const refreshThreads = useSetAtom(refreshThreadsAtom);
   const updateActiveThreadSettings = useSetAtom(updateThreadSettingsAtom);
@@ -241,8 +239,7 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
 
   const handleDeleteAllChats = async () => {
     abortAllStreams();
-    setActiveChatJob(null);
-    setQueuedChatJobs([]);
+    resetChatQueue();
     clearThreadMessages();
     await deleteAllChats();
     setThread(getDefaultThread((await getUserSettings()) || undefined));
@@ -256,8 +253,7 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
 
   const handleResetAllData = async () => {
     abortAllStreams();
-    setActiveChatJob(null);
-    setQueuedChatJobs([]);
+    resetChatQueue();
     clearThreadMessages();
     await clearLocalData();
     if (user?.id) await resetVault(user.id);

--- a/apps/client/app/components/AppSidebar/index.tsx
+++ b/apps/client/app/components/AppSidebar/index.tsx
@@ -12,9 +12,10 @@ import {
 import { useClerk, useAuth, useUser } from '@clerk/react-router';
 import { toast } from 'sonner';
 
-import { messagesAtom, threadLoadingAtom, userSettingsOpenAtom } from '@/store';
+import { messagesAtom, userSettingsOpenAtom } from '@/store';
 import { getName } from '@/utils';
 import { setActiveAccount } from '@/utils/byok-vault';
+import { abortAllStreams } from '@/utils/chat-stream-registry';
 import { Button } from '@/components/ui/button';
 import {
   Sidebar,
@@ -42,7 +43,6 @@ import UserSettingsDialog from './UserSettingsDialog';
 
 const AppSidebar = () => {
   const message = useAtomValue(messagesAtom);
-  const isChatLoading = useAtomValue(threadLoadingAtom);
   const [isUserSettingsOpen, setIsUserSettingsOpen] = useAtom(userSettingsOpenAtom);
 
   const navigate = useNavigate();
@@ -52,11 +52,6 @@ const AppSidebar = () => {
   const { setOpenMobile, isMobile } = useSidebar();
 
   const addNewChat = useCallback(() => {
-    if (isChatLoading) {
-      toast.info('Stop generating before starting a new chat.');
-      return;
-    }
-
     setOpenMobile(false);
 
     if (message.length === 0) {
@@ -68,7 +63,7 @@ const AppSidebar = () => {
     }
 
     navigate('/');
-  }, [isChatLoading, navigate, setOpenMobile, message]);
+  }, [navigate, setOpenMobile, message]);
 
   return (
     <aside>
@@ -153,6 +148,7 @@ const AppSidebar = () => {
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onClick={() => {
+                      abortAllStreams();
                       setActiveAccount(null);
                       void signOut({ redirectUrl: window.location.origin });
                     }}>

--- a/apps/client/app/components/AppSidebar/index.tsx
+++ b/apps/client/app/components/AppSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import {
   LogOutIcon,
   PlusIcon,
@@ -12,7 +12,12 @@ import {
 import { useClerk, useAuth, useUser } from '@clerk/react-router';
 import { toast } from 'sonner';
 
-import { messagesAtom, userSettingsOpenAtom } from '@/store';
+import {
+  messagesAtom,
+  resetChatQueueAtom,
+  userSettingsOpenAtom,
+  waitForPersistence,
+} from '@/store';
 import { getName } from '@/utils';
 import { setActiveAccount } from '@/utils/byok-vault';
 import { abortAllStreams } from '@/utils/chat-stream-registry';
@@ -44,6 +49,7 @@ import UserSettingsDialog from './UserSettingsDialog';
 const AppSidebar = () => {
   const message = useAtomValue(messagesAtom);
   const [isUserSettingsOpen, setIsUserSettingsOpen] = useAtom(userSettingsOpenAtom);
+  const resetChatQueue = useSetAtom(resetChatQueueAtom);
 
   const navigate = useNavigate();
   const clerk = useClerk();
@@ -147,10 +153,16 @@ const AppSidebar = () => {
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    onClick={() => {
+                    onClick={async () => {
                       abortAllStreams();
+                      resetChatQueue();
+                      try {
+                        await waitForPersistence();
+                      } catch (error) {
+                        console.error('Failed to finish saving before logout', error);
+                      }
                       setActiveAccount(null);
-                      void signOut({ redirectUrl: window.location.origin });
+                      await signOut({ redirectUrl: window.location.origin });
                     }}>
                     <LogOutIcon />
                     Log out

--- a/apps/client/app/components/ChatQueueProvider.tsx
+++ b/apps/client/app/components/ChatQueueProvider.tsx
@@ -3,18 +3,27 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import {
   activeChatJobAtom,
+  dequeueNextChatJobAtom,
   queuedChatJobsAtom,
+  resetChatQueueAtom,
   threadChatErrorsAtom,
   threadAtom,
   upsertThreadMessageAtom,
   type ChatJob,
 } from '@/store';
-import { abortAllStreams, clearActiveStream, registerActiveStream } from '@/utils/chat-stream-registry';
+import {
+  abortAllStreams,
+  clearActiveStream,
+  isDiscardedStream,
+  registerActiveStream,
+} from '@/utils/chat-stream-registry';
 import useHandleChatResponse from '@/hooks/useHandleChatResponse';
 
 const ChatQueueProvider = () => {
   const [activeJob, setActiveJob] = useAtom(activeChatJobAtom);
-  const [queuedJobs, setQueuedJobs] = useAtom(queuedChatJobsAtom);
+  const queuedJobs = useAtomValue(queuedChatJobsAtom);
+  const dequeueNextChatJob = useSetAtom(dequeueNextChatJobAtom);
+  const resetChatQueue = useSetAtom(resetChatQueueAtom);
   const setErrors = useSetAtom(threadChatErrorsAtom);
   const selectedThread = useAtomValue(threadAtom);
   const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
@@ -30,11 +39,8 @@ const ChatQueueProvider = () => {
 
   useEffect(() => {
     if (activeJob || !queuedJobs.length) return;
-
-    const [nextJob, ...remainingJobs] = queuedJobs;
-    setQueuedJobs(remainingJobs);
-    setActiveJob(nextJob);
-  }, [activeJob, queuedJobs, setActiveJob, setQueuedJobs]);
+    dequeueNextChatJob();
+  }, [activeJob, dequeueNextChatJob, queuedJobs.length]);
 
   useEffect(() => {
     if (!activeJob) return;
@@ -60,8 +66,12 @@ const ChatQueueProvider = () => {
       },
     });
 
-    void handleChatResponseRef.current({ job, signal: controller.signal })
+    void handleChatResponseRef
+      .current({ job, signal: controller.signal })
       .then((result) => {
+        if (isDiscardedStream(controller.signal)) return;
+        if (result.status === 'discarded') return;
+
         if (result.status === 'failed') {
           if (selectedThreadIdRef.current !== job.threadId) {
             setErrors((current) => ({ ...current, [job.threadId]: result.error }));
@@ -110,10 +120,9 @@ const ChatQueueProvider = () => {
   useEffect(
     () => () => {
       abortAllStreams();
-      setActiveJob(null);
-      setQueuedJobs([]);
+      resetChatQueue();
     },
-    [setActiveJob, setQueuedJobs]
+    [resetChatQueue]
   );
 
   return null;

--- a/apps/client/app/components/ChatQueueProvider.tsx
+++ b/apps/client/app/components/ChatQueueProvider.tsx
@@ -20,6 +20,9 @@ const ChatQueueProvider = () => {
   const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
   const { handleChatResponse } = useHandleChatResponse();
   const handleChatResponseRef = useRef(handleChatResponse);
+  const selectedThreadIdRef = useRef(selectedThread?.id);
+
+  selectedThreadIdRef.current = selectedThread?.id;
 
   useEffect(() => {
     handleChatResponseRef.current = handleChatResponse;
@@ -60,7 +63,7 @@ const ChatQueueProvider = () => {
     void handleChatResponseRef.current({ job, signal: controller.signal })
       .then((result) => {
         if (result.status === 'failed') {
-          if (selectedThread?.id !== job.threadId) {
+          if (selectedThreadIdRef.current !== job.threadId) {
             setErrors((current) => ({ ...current, [job.threadId]: result.error }));
           }
           upsertThreadMessage({
@@ -102,7 +105,7 @@ const ChatQueueProvider = () => {
         clearActiveStream(controller);
         setActiveJob((current) => (current?.id === job.id ? null : current));
       });
-  }, [activeJob, selectedThread?.id, setActiveJob, setErrors, upsertThreadMessage]);
+  }, [activeJob, setActiveJob, setErrors, upsertThreadMessage]);
 
   useEffect(
     () => () => {

--- a/apps/client/app/components/ChatQueueProvider.tsx
+++ b/apps/client/app/components/ChatQueueProvider.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from 'react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+
+import {
+  activeChatJobAtom,
+  queuedChatJobsAtom,
+  threadChatErrorsAtom,
+  threadAtom,
+  upsertThreadMessageAtom,
+  type ChatJob,
+} from '@/store';
+import { abortAllStreams, clearActiveStream, registerActiveStream } from '@/utils/chat-stream-registry';
+import useHandleChatResponse from '@/hooks/useHandleChatResponse';
+
+const ChatQueueProvider = () => {
+  const [activeJob, setActiveJob] = useAtom(activeChatJobAtom);
+  const [queuedJobs, setQueuedJobs] = useAtom(queuedChatJobsAtom);
+  const setErrors = useSetAtom(threadChatErrorsAtom);
+  const selectedThread = useAtomValue(threadAtom);
+  const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
+  const { handleChatResponse } = useHandleChatResponse();
+  const handleChatResponseRef = useRef(handleChatResponse);
+
+  useEffect(() => {
+    handleChatResponseRef.current = handleChatResponse;
+  }, [handleChatResponse]);
+
+  useEffect(() => {
+    if (activeJob || !queuedJobs.length) return;
+
+    const [nextJob, ...remainingJobs] = queuedJobs;
+    setQueuedJobs(remainingJobs);
+    setActiveJob(nextJob);
+  }, [activeJob, queuedJobs, setActiveJob, setQueuedJobs]);
+
+  useEffect(() => {
+    if (!activeJob) return;
+
+    const job = activeJob as ChatJob;
+    const controller = new AbortController();
+    registerActiveStream(job.threadId, controller);
+
+    upsertThreadMessage({
+      threadId: job.threadId,
+      message: {
+        id: job.userMessageId,
+        role: 'user',
+        content: job.prompt,
+        type: 'text',
+        metadata: {
+          model: job.thread.settings.model,
+          profile: null,
+          timestamp: job.createdAt,
+          requestId: job.id,
+          requestState: 'streaming',
+        },
+      },
+    });
+
+    void handleChatResponseRef.current({ job, signal: controller.signal })
+      .then((result) => {
+        if (result.status === 'failed') {
+          if (selectedThread?.id !== job.threadId) {
+            setErrors((current) => ({ ...current, [job.threadId]: result.error }));
+          }
+          upsertThreadMessage({
+            threadId: job.threadId,
+            message: {
+              id: job.userMessageId,
+              role: 'user',
+              content: job.prompt,
+              type: 'text',
+              metadata: {
+                model: job.thread.settings.model,
+                profile: null,
+                timestamp: job.createdAt,
+                requestId: job.id,
+                requestState: 'failed',
+              },
+            },
+          });
+          return;
+        }
+
+        upsertThreadMessage({
+          threadId: job.threadId,
+          message: {
+            id: job.userMessageId,
+            role: 'user',
+            content: job.prompt,
+            type: 'text',
+            metadata: {
+              model: job.thread.settings.model,
+              profile: null,
+              timestamp: job.createdAt,
+              requestId: job.id,
+            },
+          },
+        });
+      })
+      .finally(() => {
+        clearActiveStream(controller);
+        setActiveJob((current) => (current?.id === job.id ? null : current));
+      });
+  }, [activeJob, selectedThread?.id, setActiveJob, setErrors, upsertThreadMessage]);
+
+  useEffect(
+    () => () => {
+      abortAllStreams();
+      setActiveJob(null);
+      setQueuedJobs([]);
+    },
+    [setActiveJob, setQueuedJobs]
+  );
+
+  return null;
+};
+
+export default ChatQueueProvider;

--- a/apps/client/app/components/Input/index.tsx
+++ b/apps/client/app/components/Input/index.tsx
@@ -1,5 +1,5 @@
 import { EditorContent, useEditorState } from '@tiptap/react';
-import { SendHorizonal, Square, VolumeX } from 'lucide-react';
+import { SendHorizonal, Square, VolumeX, XIcon } from 'lucide-react';
 import { useAtomValue } from 'jotai';
 
 import useCustomTiptapEditor from '@/hooks/useCustomEditor';
@@ -10,7 +10,7 @@ import Voice from '@/components/Input/Voice';
 import { Button } from '@/components/ui/button';
 
 const Text = () => {
-  const { editor, handleSubmit, isChatLoading, stopChat } = useCustomTiptapEditor();
+  const { editor, handleSubmit, isChatLoading, isQueued, stopChat, cancelQueued } = useCustomTiptapEditor();
   const isSpeaking = useAtomValue(speechPlaybackAtom);
   const { cancel } = useSpeechSynthesis();
   const hasText = useEditorState({
@@ -49,6 +49,16 @@ const Text = () => {
             onClick={stopChat}>
             <Square className="size-4 fill-current" />
             <span className="sr-only">Stop generating</span>
+          </Button>
+        ) : isQueued ? (
+          <Button
+            type="button"
+            title="Cancel queued message"
+            aria-label="Cancel queued message"
+            className="size-10 rounded-full border border-muted-foreground/30 bg-muted p-0 sm:size-11"
+            onClick={cancelQueued}>
+            <XIcon className="size-4" />
+            <span className="sr-only">Cancel queued message</span>
           </Button>
         ) : !hasText && IS_SPEECH_RECOGNITION_SUPPORTED() ? (
           <Voice />

--- a/apps/client/app/components/Input/index.tsx
+++ b/apps/client/app/components/Input/index.tsx
@@ -56,7 +56,10 @@ const Text = () => {
             title="Cancel queued message"
             aria-label="Cancel queued message"
             className="size-10 rounded-full border border-muted-foreground/30 bg-muted p-0 sm:size-11"
-            onClick={cancelQueued}>
+            onClick={(event) => {
+              event.preventDefault();
+              cancelQueued();
+            }}>
             <XIcon className="size-4" />
             <span className="sr-only">Cancel queued message</span>
           </Button>

--- a/apps/client/app/components/Message/index.tsx
+++ b/apps/client/app/components/Message/index.tsx
@@ -35,7 +35,7 @@ const MessageContent = ({
   content,
   image_url: image,
   role,
-  metadata: { model, usage, finishReason, cancelled },
+  metadata: { model, usage, finishReason, cancelled, requestState },
 }: MessageProps) => {
   const shouldReduceMotion = useReducedMotion();
   const showDetailedUsage = useAtomValue(threadAtom)?.settings.showDetailedUsage ?? false;
@@ -160,6 +160,16 @@ const MessageContent = ({
               {!isUser && cancelled && (
                 <span className="inline-flex items-center rounded-full border border-muted-foreground/20 bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                   Cancelled
+                </span>
+              )}
+              {isUser && requestState === 'failed' && (
+                <span className="inline-flex items-center rounded-full border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-destructive">
+                  Response failed
+                </span>
+              )}
+              {isUser && requestState === 'interrupted' && (
+                <span className="inline-flex items-center rounded-full border border-muted-foreground/20 bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Interrupted
                 </span>
               )}
             </div>

--- a/apps/client/app/components/Thread/Empty.tsx
+++ b/apps/client/app/components/Thread/Empty.tsx
@@ -50,7 +50,7 @@ const Empty = ({ name }: IEmpty) => {
   const setUserSettingsOpen = useSetAtom(userSettingsOpenAtom);
   const setUserSettingsScrollTarget = useSetAtom(userSettingsScrollTargetAtom);
 
-  const { isChatLoading, submitMessage } = useSubmitMessage();
+  const { isChatLoading, isQueued, submitMessage } = useSubmitMessage();
 
   const hints = useMemo(
     () => profiles.find(({ code }) => code === profile)?.hints,
@@ -93,7 +93,7 @@ const Empty = ({ name }: IEmpty) => {
                   key={hint}
                   variant="outline"
                   onClick={() => submitMessage(hint)}
-                  disabled={isChatLoading}
+                  disabled={isChatLoading || isQueued}
                   className="h-full min-w-0 rounded-xl bg-card/70 px-3 py-3 text-left shadow-sm hover:border-primary/50 hover:bg-accent/70">
                   <p className="max-w-full whitespace-break-spaces [overflow-wrap:anywhere]">
                     {hint}

--- a/apps/client/app/components/Thread/index.tsx
+++ b/apps/client/app/components/Thread/index.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai';
 import { useUser } from '@clerk/react-router';
 import clsx from 'clsx';
 
-import { threadLoadingAtom, messagesAtom } from '@/store';
+import { threadLoadingAtom, messagesAtom, threadQueuedJobAtom } from '@/store';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import Message from '@/components/Message';
 import { getName } from '@/utils';
@@ -29,6 +29,7 @@ interface ThreadProps {
 const Thread = ({ className }: ThreadProps) => {
   const messages = useAtomValue(messagesAtom);
   const isChatResponseLoading = useAtomValue(threadLoadingAtom);
+  const queuedJob = useAtomValue(threadQueuedJobAtom);
   const { user } = useUser();
   const shouldStickToBottom = useRef(true);
   const hasInitialScroll = useRef(false);
@@ -108,6 +109,11 @@ const Thread = ({ className }: ThreadProps) => {
               return <Message key={chat.id} {...userInfo(metadata.profile)[role]} {...chat} />;
             })}
             {isChatResponseLoading && <Typing />}
+            {queuedJob && (
+              <p className="px-2 py-3 text-center text-sm text-muted-foreground" role="status">
+                Queued - waiting for the current response to finish.
+              </p>
+            )}
             <UsageStatus />
             <div ref={bottomSentinelRef} aria-hidden="true" className="h-px" />
           </>

--- a/apps/client/app/hooks/useCustomEditor.tsx
+++ b/apps/client/app/hooks/useCustomEditor.tsx
@@ -19,7 +19,7 @@ const extensions = [
 
 const useCustomEditor = () => {
   const [editorState, setEditorState] = useAtom(editorAtom);
-  const { isChatLoading, submitMessage, stopChat } = useSubmitMessage();
+  const { isChatLoading, isQueued, submitMessage, stopChat, cancelQueuedMessage } = useSubmitMessage();
 
   const editor = useEditor({
     extensions,
@@ -74,6 +74,15 @@ const useCustomEditor = () => {
     return true;
   }, [editor, setEditorState, submitMessage]);
 
+  const cancelQueued = useCallback(() => {
+    const prompt = cancelQueuedMessage();
+    if (!prompt || !editor) return;
+    const content = `<p>${prompt}</p>`;
+    editor.commands.setContent(content, false);
+    setEditorState(content);
+    editor.commands.focus('end');
+  }, [cancelQueuedMessage, editor, setEditorState]);
+
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
 
@@ -84,7 +93,7 @@ const useCustomEditor = () => {
     editor.commands.focus('end');
   }, [editor, editorState]);
 
-  return { editor, handleSubmit, isChatLoading, stopChat };
+  return { editor, handleSubmit, isChatLoading, isQueued, stopChat, cancelQueued };
 };
 
 export default useCustomEditor;

--- a/apps/client/app/hooks/useCustomEditor.tsx
+++ b/apps/client/app/hooks/useCustomEditor.tsx
@@ -19,7 +19,8 @@ const extensions = [
 
 const useCustomEditor = () => {
   const [editorState, setEditorState] = useAtom(editorAtom);
-  const { isChatLoading, isQueued, submitMessage, stopChat, cancelQueuedMessage } = useSubmitMessage();
+  const { isChatLoading, isQueued, submitMessage, stopChat, cancelQueuedMessage } =
+    useSubmitMessage();
 
   const editor = useEditor({
     extensions,
@@ -77,9 +78,24 @@ const useCustomEditor = () => {
   const cancelQueued = useCallback(() => {
     const prompt = cancelQueuedMessage();
     if (!prompt || !editor) return;
-    const content = `<p>${prompt}</p>`;
-    editor.commands.setContent(content, false);
-    setEditorState(content);
+
+    const promptContent = prompt.split('\n').map((line) => ({
+      type: 'paragraph',
+      ...(line ? { content: [{ type: 'text', text: line }] } : {}),
+    }));
+    const draftContent = editor.isEmpty ? [] : editor.getJSON().content || [];
+
+    editor.commands.setContent(
+      {
+        type: 'doc',
+        content: [
+          ...promptContent,
+          ...(draftContent.length ? [{ type: 'paragraph' }, ...draftContent] : []),
+        ],
+      },
+      false
+    );
+    setEditorState(editor.getHTML());
     editor.commands.focus('end');
   }, [cancelQueuedMessage, editor, setEditorState]);
 

--- a/apps/client/app/hooks/useHandleChatResponse.tsx
+++ b/apps/client/app/hooks/useHandleChatResponse.tsx
@@ -18,6 +18,7 @@ import {
   userSettingsScrollTargetAtom,
 } from '@/store';
 import { ChatStreamPart, getGeneratedText, getGeneratedImage } from '@/utils/api-calls';
+import { isDiscardedStream } from '@/utils/chat-stream-registry';
 import { markStartedToastAsSeen } from '@/utils/lforage';
 import { Button } from '@/components/ui/button';
 import useSpeechSynthesis from './useSpeechSynthesis';
@@ -115,6 +116,8 @@ const useHandleChatResponse = () => {
     let isSharedApiRequest = true;
 
     try {
+      if (user?.id !== job.accountId) return { status: 'discarded' as const };
+
       const provider = providerForModel(thread.settings.model);
       const apiKey = user?.id ? getProviderKey(user.id, provider) : undefined;
       isSharedApiRequest = !apiKey;
@@ -125,6 +128,7 @@ const useHandleChatResponse = () => {
         isSharedApiRequest = false;
         throw new Error(`Unlock your ${provider} BYOK vault key before chatting.`);
       }
+      if (signal?.aborted) return { status: 'cancelled' as const };
 
       if (supportedImageModels.map(({ name }) => name).includes(thread.settings.model)) {
         const imageResponse = await getGeneratedImage({
@@ -141,6 +145,7 @@ const useHandleChatResponse = () => {
         if (!('b64_json' in imageResponse)) {
           throw Object.assign(new Error(imageResponse.err), { status: imageResponse.status });
         }
+        if (signal?.aborted) return { status: 'cancelled' as const };
 
         const { b64_json } = imageResponse;
 
@@ -208,6 +213,8 @@ const useHandleChatResponse = () => {
         let updateTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
         const saveAssistantMessage = (finishReason?: string, cancelled = false) => {
+          if (isDiscardedStream(signal)) return;
+
           upsertThreadMessage({
             threadId: thread.id,
             message: {
@@ -238,6 +245,8 @@ const useHandleChatResponse = () => {
 
         const updateMessage = () => {
           updateTimeoutId = null;
+          if (isDiscardedStream(signal)) return;
+
           startTransition(() => {
             upsertThreadMessage({
               threadId: thread.id,
@@ -268,6 +277,15 @@ const useHandleChatResponse = () => {
         try {
           while (true) {
             const { value, done } = await reader.read();
+
+            if (signal?.aborted) {
+              if (updateTimeoutId !== null) {
+                clearTimeout(updateTimeoutId);
+                updateTimeoutId = null;
+              }
+              if (content || responseMetadata) saveAssistantMessage('stop', true);
+              return { status: 'cancelled' as const };
+            }
 
             // Stream is completed
             if (done) {
@@ -300,11 +318,20 @@ const useHandleChatResponse = () => {
             }
           }
         } catch (error) {
-          if (!signal?.aborted) throw error;
-
           if (updateTimeoutId !== null) {
             clearTimeout(updateTimeoutId);
             updateTimeoutId = null;
+          }
+
+          try {
+            await reader.cancel();
+          } catch {
+            // The request may already have closed the reader while aborting.
+          }
+
+          if (!signal?.aborted) {
+            if (content || responseMetadata) saveAssistantMessage('error');
+            throw error;
           }
 
           // Keep the generated portion visible after Stop. If the provider

--- a/apps/client/app/hooks/useHandleChatResponse.tsx
+++ b/apps/client/app/hooks/useHandleChatResponse.tsx
@@ -148,20 +148,21 @@ const useHandleChatResponse = () => {
           upsertThreadMessage({
             threadId: thread.id,
             message: {
-            id: crypto.randomUUID(),
-            content: ``,
-            image_url: {
-              url: `data:image/png;base64,${b64_json}`,
-              alt: prompt,
-              size: imageSize,
-            },
-            role: 'assistant',
-            type: 'image_url',
-            metadata: {
-              model: thread.settings.model,
-              profile: thread.settings.profile,
-              timestamp: getTime(new Date()),
-            },
+              id: job.assistantMessageId,
+              content: ``,
+              image_url: {
+                url: `data:image/png;base64,${b64_json}`,
+                alt: prompt,
+                size: imageSize,
+              },
+              role: 'assistant',
+              type: 'image_url',
+              metadata: {
+                model: thread.settings.model,
+                profile: thread.settings.profile,
+                timestamp: getTime(new Date()),
+                requestId: job.id,
+              },
             },
           });
           // Haptic feedback and sound
@@ -201,7 +202,6 @@ const useHandleChatResponse = () => {
         }
 
         const reader = (stream as ReadableStream<ChatStreamPart>).getReader();
-        const uid = crypto.randomUUID();
         const timestamp = getTime(new Date());
         let content = '';
         let responseMetadata: Extract<ChatStreamPart, { type: 'metadata' }> | undefined;
@@ -211,26 +211,27 @@ const useHandleChatResponse = () => {
           upsertThreadMessage({
             threadId: thread.id,
             message: {
-            id: uid,
-            content,
-            metadata: {
-              model: thread.settings.model,
-              profile: thread.settings.profile,
-              timestamp,
-              ...(responseMetadata
-                ? {
-                  usage: responseMetadata.metadata.usage,
-                  finishReason: responseMetadata.metadata.finishReason,
-                  responseId: responseMetadata.metadata.responseId,
-                  responseModelId: responseMetadata.metadata.modelId,
-                  responseTimestamp: responseMetadata.metadata.timestamp,
-                }
-                : {}),
-              ...(finishReason ? { finishReason } : {}),
-              ...(cancelled ? { cancelled: true } : {}),
-            },
-            role: 'assistant',
-            type: 'text',
+              id: job.assistantMessageId,
+              content,
+              metadata: {
+                model: thread.settings.model,
+                profile: thread.settings.profile,
+                timestamp,
+                requestId: job.id,
+                ...(responseMetadata
+                  ? {
+                      usage: responseMetadata.metadata.usage,
+                      finishReason: responseMetadata.metadata.finishReason,
+                      responseId: responseMetadata.metadata.responseId,
+                      responseModelId: responseMetadata.metadata.modelId,
+                      responseTimestamp: responseMetadata.metadata.timestamp,
+                    }
+                  : {}),
+                ...(finishReason ? { finishReason } : {}),
+                ...(cancelled ? { cancelled: true } : {}),
+              },
+              role: 'assistant',
+              type: 'text',
             },
           });
         };
@@ -241,15 +242,16 @@ const useHandleChatResponse = () => {
             upsertThreadMessage({
               threadId: thread.id,
               message: {
-              id: uid,
-              content,
-              metadata: {
-                model: thread.settings.model,
-                timestamp,
-                profile: thread.settings.profile,
-              },
-              role: 'assistant',
-              type: 'text',
+                id: job.assistantMessageId,
+                content,
+                metadata: {
+                  model: thread.settings.model,
+                  timestamp,
+                  profile: thread.settings.profile,
+                  requestId: job.id,
+                },
+                role: 'assistant',
+                type: 'text',
               },
             });
           });

--- a/apps/client/app/hooks/useHandleChatResponse.tsx
+++ b/apps/client/app/hooks/useHandleChatResponse.tsx
@@ -11,12 +11,9 @@ import { providerForModel } from '@/utils/byok-providers';
 import { getProviderKey, isProviderConfigured } from '@/utils/byok-vault';
 
 import {
-  threadAtom,
-  messagesAtom,
-  upsertMessageAtom,
-  threadLoadingAtom,
-  configAtom,
-  IMessage,
+  type ChatJob,
+  type IMessage,
+  upsertThreadMessageAtom,
   userSettingsOpenAtom,
   userSettingsScrollTargetAtom,
 } from '@/store';
@@ -89,20 +86,12 @@ const showStartedToastOnce = async (openSettings: () => void) => {
 };
 
 interface handleChatResponseProps {
-  prompt: string;
+  job: ChatJob;
   signal?: AbortSignal;
-  onTextMessageComplete?: (content: string) => void;
-  onImageMessageComplete?: () => void;
 }
 
 const useHandleChatResponse = () => {
-  const config = useAtomValue(configAtom);
-  const { imageSize, language, quality, style } = config;
-  const customInstructions = config.customInstructions || '';
-  const thread = useAtomValue(threadAtom);
-  const messages = useAtomValue(messagesAtom);
-  const upsertMessage = useSetAtom(upsertMessageAtom);
-  const setIsChatResponseLoading = useSetAtom(threadLoadingAtom);
+  const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
   const setSettingsOpen = useSetAtom(userSettingsOpenAtom);
   const setSettingsScrollTarget = useSetAtom(userSettingsScrollTargetAtom);
   const [isPending, startTransition] = useTransition();
@@ -117,15 +106,15 @@ const useHandleChatResponse = () => {
   };
 
   const handleChatResponse = async ({
-    prompt,
+    job,
     signal,
-    onTextMessageComplete,
-    onImageMessageComplete,
   }: handleChatResponseProps) => {
+    const { prompt, thread, messages, config } = job;
+    const { imageSize, language, quality, style } = config;
+    const customInstructions = config.customInstructions || '';
     let isSharedApiRequest = true;
 
     try {
-      if (!thread) throw new Error('Thread not created');
       const provider = providerForModel(thread.settings.model);
       const apiKey = user?.id ? getProviderKey(user.id, provider) : undefined;
       isSharedApiRequest = !apiKey;
@@ -156,7 +145,9 @@ const useHandleChatResponse = () => {
         const { b64_json } = imageResponse;
 
         startTransition(() => {
-          upsertMessage({
+          upsertThreadMessage({
+            threadId: thread.id,
+            message: {
             id: crypto.randomUUID(),
             content: ``,
             image_url: {
@@ -171,9 +162,8 @@ const useHandleChatResponse = () => {
               profile: thread.settings.profile,
               timestamp: getTime(new Date()),
             },
+            },
           });
-
-          setIsChatResponseLoading(false);
           // Haptic feedback and sound
           navigator.vibrate(100);
           play();
@@ -181,7 +171,7 @@ const useHandleChatResponse = () => {
 
         await showStartedToastOnce(openByokSettings);
 
-        if (onImageMessageComplete) onImageMessageComplete();
+        return { status: 'completed' as const };
       } else {
         const stream = await getGeneratedText({
           ...(thread.settings.conversationContextMode === 'multi-turn'
@@ -218,7 +208,9 @@ const useHandleChatResponse = () => {
         let updateTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
         const saveAssistantMessage = (finishReason?: string, cancelled = false) => {
-          upsertMessage({
+          upsertThreadMessage({
+            threadId: thread.id,
+            message: {
             id: uid,
             content,
             metadata: {
@@ -239,13 +231,16 @@ const useHandleChatResponse = () => {
             },
             role: 'assistant',
             type: 'text',
+            },
           });
         };
 
         const updateMessage = () => {
           updateTimeoutId = null;
           startTransition(() => {
-            upsertMessage({
+            upsertThreadMessage({
+              threadId: thread.id,
+              message: {
               id: uid,
               content,
               metadata: {
@@ -255,6 +250,7 @@ const useHandleChatResponse = () => {
               },
               role: 'assistant',
               type: 'text',
+              },
             });
           });
         };
@@ -315,32 +311,35 @@ const useHandleChatResponse = () => {
           if (content || responseMetadata) saveAssistantMessage('stop', true);
         }
 
-        if (onTextMessageComplete) onTextMessageComplete(content);
+        return { status: signal?.aborted ? ('cancelled' as const) : ('completed' as const) };
       }
     } catch (err) {
-      if (signal?.aborted) return;
+      if (signal?.aborted) return { status: 'cancelled' as const };
 
       console.error(err);
 
       if (axios.isAxiosError(err)) {
-        return showResponseErrorToast(
+        showResponseErrorToast(
           err.response?.data.err || err.message,
           isSharedApiRequest,
           openByokSettings,
           err.response?.status
         );
+        return { status: 'failed' as const, error: err.response?.data.err || err.message };
       }
 
       if (err instanceof Error) {
-        return showResponseErrorToast(
+        showResponseErrorToast(
           err.message || 'Something went Wrong!',
           isSharedApiRequest,
           openByokSettings,
           'status' in err && typeof err.status === 'number' ? err.status : undefined
         );
+        return { status: 'failed' as const, error: err.message || 'Something went Wrong!' };
       }
 
       showResponseErrorToast('Something went Wrong!', isSharedApiRequest, openByokSettings);
+      return { status: 'failed' as const, error: 'Something went Wrong!' };
     }
   };
 

--- a/apps/client/app/hooks/useSubmitMessage.tsx
+++ b/apps/client/app/hooks/useSubmitMessage.tsx
@@ -3,17 +3,29 @@ import { getTime } from 'date-fns';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 
-import { chatAbortControllerAtom, threadAtom, threadLoadingAtom, upsertMessageAtom } from '@/store';
-
-import useHandleChatResponse from './useHandleChatResponse';
+import {
+  activeChatJobAtom,
+  configAtom,
+  messagesAtom,
+  queuedChatJobsAtom,
+  removeThreadMessageAtom,
+  threadAtom,
+  threadLoadingAtom,
+  threadQueuedJobAtom,
+  upsertThreadMessageAtom,
+} from '@/store';
+import { abortThreadStream } from '@/utils/chat-stream-registry';
 
 const useSubmitMessage = () => {
   const thread = useAtomValue(threadAtom);
+  const messages = useAtomValue(messagesAtom);
+  const config = useAtomValue(configAtom);
   const isChatLoading = useAtomValue(threadLoadingAtom);
-  const addChat = useSetAtom(upsertMessageAtom);
-  const setIsChatResponseLoading = useSetAtom(threadLoadingAtom);
-  const [abortController, setAbortController] = useAtom(chatAbortControllerAtom);
-  const { handleChatResponse } = useHandleChatResponse();
+  const queuedJob = useAtomValue(threadQueuedJobAtom);
+  const activeJob = useAtomValue(activeChatJobAtom);
+  const [, setQueuedJobs] = useAtom(queuedChatJobsAtom);
+  const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
+  const removeThreadMessage = useSetAtom(removeThreadMessageAtom);
 
   const submitMessage = useCallback(
     (rawPrompt: string) => {
@@ -24,55 +36,59 @@ const useSubmitMessage = () => {
         return false;
       }
 
-      if (!prompt || isChatLoading) return false;
+      if (!prompt || isChatLoading || queuedJob) return false;
 
-      addChat({
-        id: crypto.randomUUID(),
-        role: 'user',
-        content: prompt,
-        metadata: {
-          model: thread.settings.model,
-          profile: null,
-          timestamp: getTime(new Date()),
+      const id = crypto.randomUUID();
+      const createdAt = getTime(new Date());
+      upsertThreadMessage({
+        threadId: thread.id,
+        message: {
+          id,
+          role: 'user',
+          content: prompt,
+          metadata: {
+            model: thread.settings.model,
+            profile: null,
+            timestamp: createdAt,
+            requestId: id,
+            requestState: activeJob ? 'queued' : 'streaming',
+          },
+          type: 'text',
         },
-        type: 'text',
       });
 
-      const controller = new AbortController();
-      setAbortController(controller);
-      setIsChatResponseLoading(true);
-
-      void handleChatResponse({ prompt, signal: controller.signal })
-        .catch((error) => {
-          if (!controller.signal.aborted) {
-            console.error(error);
-            toast.error('The message could not be sent.');
-          }
-        })
-        .finally(() => {
-          setAbortController((currentController) =>
-            currentController === controller ? null : currentController
-          );
-          setIsChatResponseLoading(false);
-        });
+      setQueuedJobs((current) => [
+        ...current,
+        {
+          id,
+          threadId: thread.id,
+          prompt,
+          userMessageId: id,
+          thread,
+          messages,
+          config,
+          createdAt,
+        },
+      ]);
 
       return true;
     },
-    [
-      addChat,
-      handleChatResponse,
-      isChatLoading,
-      setAbortController,
-      setIsChatResponseLoading,
-      thread,
-    ]
+    [activeJob, config, isChatLoading, messages, queuedJob, setQueuedJobs, thread, upsertThreadMessage]
   );
 
   const stopChat = useCallback(() => {
-    abortController?.abort();
-  }, [abortController]);
+    if (thread) abortThreadStream(thread.id);
+  }, [thread]);
 
-  return { isChatLoading, submitMessage, stopChat };
+  const cancelQueuedMessage = useCallback(() => {
+    if (!queuedJob || !thread) return null;
+
+    setQueuedJobs((current) => current.filter((job) => job.id !== queuedJob.id));
+    removeThreadMessage({ threadId: thread.id, id: queuedJob.userMessageId });
+    return queuedJob.prompt;
+  }, [queuedJob, removeThreadMessage, setQueuedJobs, thread]);
+
+  return { isChatLoading, isQueued: Boolean(queuedJob), submitMessage, stopChat, cancelQueuedMessage };
 };
 
 export default useSubmitMessage;

--- a/apps/client/app/hooks/useSubmitMessage.tsx
+++ b/apps/client/app/hooks/useSubmitMessage.tsx
@@ -1,18 +1,17 @@
 import { useCallback } from 'react';
 import { getTime } from 'date-fns';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useUser } from '@clerk/react-router';
 import { toast } from 'sonner';
 
 import {
-  activeChatJobAtom,
+  cancelQueuedChatJobAtom,
   configAtom,
+  enqueueChatJobAtom,
   messagesAtom,
-  queuedChatJobsAtom,
-  removeThreadMessageAtom,
   threadAtom,
   threadLoadingAtom,
   threadQueuedJobAtom,
-  upsertThreadMessageAtom,
 } from '@/store';
 import { abortThreadStream } from '@/utils/chat-stream-registry';
 
@@ -22,60 +21,38 @@ const useSubmitMessage = () => {
   const config = useAtomValue(configAtom);
   const isChatLoading = useAtomValue(threadLoadingAtom);
   const queuedJob = useAtomValue(threadQueuedJobAtom);
-  const activeJob = useAtomValue(activeChatJobAtom);
-  const [, setQueuedJobs] = useAtom(queuedChatJobsAtom);
-  const upsertThreadMessage = useSetAtom(upsertThreadMessageAtom);
-  const removeThreadMessage = useSetAtom(removeThreadMessageAtom);
+  const enqueueChatJob = useSetAtom(enqueueChatJobAtom);
+  const cancelQueuedChatJob = useSetAtom(cancelQueuedChatJobAtom);
+  const { user } = useUser();
 
   const submitMessage = useCallback(
     (rawPrompt: string) => {
       const prompt = rawPrompt.trim();
 
-      if (!thread) {
+      if (!thread || !user?.id) {
         toast.error('This chat is not ready yet.');
         return false;
       }
 
-      if (!prompt || isChatLoading || queuedJob) return false;
+      if (!prompt) return false;
 
       const id = crypto.randomUUID();
       const assistantMessageId = crypto.randomUUID();
       const createdAt = getTime(new Date());
-      upsertThreadMessage({
+      return enqueueChatJob({
+        id,
+        accountId: user.id,
         threadId: thread.id,
-        message: {
-          id,
-          role: 'user',
-          content: prompt,
-          metadata: {
-            model: thread.settings.model,
-            profile: null,
-            timestamp: createdAt,
-            requestId: id,
-            requestState: activeJob ? 'queued' : 'streaming',
-          },
-          type: 'text',
-        },
+        prompt,
+        userMessageId: id,
+        assistantMessageId,
+        thread,
+        messages,
+        config,
+        createdAt,
       });
-
-      setQueuedJobs((current) => [
-        ...current,
-        {
-          id,
-          threadId: thread.id,
-          prompt,
-          userMessageId: id,
-          assistantMessageId,
-          thread,
-          messages,
-          config,
-          createdAt,
-        },
-      ]);
-
-      return true;
     },
-    [activeJob, config, isChatLoading, messages, queuedJob, setQueuedJobs, thread, upsertThreadMessage]
+    [config, enqueueChatJob, messages, thread, user?.id]
   );
 
   const stopChat = useCallback(() => {
@@ -83,14 +60,17 @@ const useSubmitMessage = () => {
   }, [thread]);
 
   const cancelQueuedMessage = useCallback(() => {
-    if (!queuedJob || !thread) return null;
+    if (!thread) return null;
+    return cancelQueuedChatJob(thread.id);
+  }, [cancelQueuedChatJob, thread]);
 
-    setQueuedJobs((current) => current.filter((job) => job.id !== queuedJob.id));
-    removeThreadMessage({ threadId: thread.id, id: queuedJob.userMessageId });
-    return queuedJob.prompt;
-  }, [queuedJob, removeThreadMessage, setQueuedJobs, thread]);
-
-  return { isChatLoading, isQueued: Boolean(queuedJob), submitMessage, stopChat, cancelQueuedMessage };
+  return {
+    isChatLoading,
+    isQueued: Boolean(queuedJob),
+    submitMessage,
+    stopChat,
+    cancelQueuedMessage,
+  };
 };
 
 export default useSubmitMessage;

--- a/apps/client/app/hooks/useSubmitMessage.tsx
+++ b/apps/client/app/hooks/useSubmitMessage.tsx
@@ -39,6 +39,7 @@ const useSubmitMessage = () => {
       if (!prompt || isChatLoading || queuedJob) return false;
 
       const id = crypto.randomUUID();
+      const assistantMessageId = crypto.randomUUID();
       const createdAt = getTime(new Date());
       upsertThreadMessage({
         threadId: thread.id,
@@ -64,6 +65,7 @@ const useSubmitMessage = () => {
           threadId: thread.id,
           prompt,
           userMessageId: id,
+          assistantMessageId,
           thread,
           messages,
           config,

--- a/apps/client/app/layouts/home.tsx
+++ b/apps/client/app/layouts/home.tsx
@@ -4,6 +4,7 @@ import { RedirectToSignIn, useAuth } from '@clerk/react-router';
 import Nav from '@/components/Nav';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/AppSidebar';
+import ChatQueueProvider from '@/components/ChatQueueProvider';
 import Loading from '@/loading';
 
 const Home = () => {
@@ -14,6 +15,7 @@ const Home = () => {
 
   return (
     <SidebarProvider>
+      <ChatQueueProvider />
       <AppSidebar />
       <main className="flex h-dvh min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
         <Nav />

--- a/apps/client/app/routes/home.tsx
+++ b/apps/client/app/routes/home.tsx
@@ -9,6 +9,8 @@ import {
   configAtom,
   configSaveEffect,
   defaultConfig,
+  clearThreadMessagesAtom,
+  hydrateThreadMessagesAtom,
   replaceMessagesAtom,
   messageSaveEffect,
   threadAtom,
@@ -36,6 +38,8 @@ export const meta = ({}: Route.MetaArgs) => [
 
 const Home = ({ params: { threadId } }: Route.ComponentProps) => {
   const setThread = useSetAtom(threadAtom);
+  const hydrateThreadMessages = useSetAtom(hydrateThreadMessagesAtom);
+  const clearThreadMessages = useSetAtom(clearThreadMessagesAtom);
   const replaceMessages = useSetAtom(replaceMessagesAtom);
   const setConfig = useSetAtom(configAtom);
   const setWorkspaceReady = useSetAtom(workspaceReadyAtom);
@@ -57,7 +61,7 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
       setActiveWorkspaceAccount(null);
       setConfig(defaultConfig);
       setThread(null);
-      replaceMessages([]);
+      clearThreadMessages();
       setIsWorkspaceLoaded(false);
       return;
     }
@@ -67,7 +71,7 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
     const loadWorkspace = async () => {
       setWorkspaceReady(false);
       setThread(null);
-      replaceMessages([]);
+      clearThreadMessages();
       setConfig(defaultConfig);
       setIsWorkspaceLoaded(false);
       setActiveWorkspaceAccount(user.id);
@@ -82,7 +86,19 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
         if (cancelled) return;
 
         const storedThreads = threads || [];
-        const storedMessages = messages || {};
+        const storedMessages = Object.fromEntries(
+          Object.entries(messages || {}).map(([id, threadMessages]) => [
+            id,
+            threadMessages.map((message) =>
+              message.metadata.requestState === 'queued' || message.metadata.requestState === 'streaming'
+                ? {
+                    ...message,
+                    metadata: { ...message.metadata, requestState: 'interrupted' as const },
+                  }
+                : message
+            ),
+          ])
+        );
         const threadData = threadId
           ? storedThreads.find((thread) => thread.id === threadId) || null
           : (() => {
@@ -123,8 +139,8 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
 
         if (cancelled) return;
         setConfig({ ...defaultConfig, ...savedConfig });
+        hydrateThreadMessages(storedMessages);
         setThread(threadData);
-        replaceMessages(storedMessages[threadData.id] || []);
         setWorkspaceReady(true);
         setIsWorkspaceLoaded(true);
 
@@ -150,6 +166,8 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
     isLoaded,
     isSignedIn,
     navigate,
+    clearThreadMessages,
+    hydrateThreadMessages,
     replaceMessages,
     setConfig,
     setThread,

--- a/apps/client/app/routes/home.tsx
+++ b/apps/client/app/routes/home.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, Suspense } from 'react';
-import { useAtom, useSetAtom } from 'jotai';
+import { useEffect, useRef, useState, Suspense } from 'react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useAuth, useUser, RedirectToSignIn } from '@clerk/react-router';
 import { useNavigate } from 'react-router';
 
@@ -14,6 +14,7 @@ import {
   replaceMessagesAtom,
   messageSaveEffect,
   threadAtom,
+  threadMessagesAtom,
   threadSaveEffect,
   workspaceReadyAtom,
 } from '@/store';
@@ -41,9 +42,14 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
   const hydrateThreadMessages = useSetAtom(hydrateThreadMessagesAtom);
   const clearThreadMessages = useSetAtom(clearThreadMessagesAtom);
   const replaceMessages = useSetAtom(replaceMessagesAtom);
+  const messagesByThread = useAtomValue(threadMessagesAtom);
   const setConfig = useSetAtom(configAtom);
   const setWorkspaceReady = useSetAtom(workspaceReadyAtom);
   const [isWorkspaceLoaded, setIsWorkspaceLoaded] = useState(false);
+  const workspaceAccountRef = useRef<string | null>(null);
+  const messagesByThreadRef = useRef(messagesByThread);
+
+  messagesByThreadRef.current = messagesByThread;
 
   const { isSignedIn, isLoaded } = useAuth();
   const { user } = useUser();
@@ -57,6 +63,7 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
 
   useEffect(() => {
     if (!isLoaded || !isSignedIn || !user?.id) {
+      workspaceAccountRef.current = null;
       setWorkspaceReady(false);
       setActiveWorkspaceAccount(null);
       setConfig(defaultConfig);
@@ -69,12 +76,16 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
     let cancelled = false;
 
     const loadWorkspace = async () => {
+      const isAccountChange = workspaceAccountRef.current !== user.id;
       setWorkspaceReady(false);
       setThread(null);
-      clearThreadMessages();
-      setConfig(defaultConfig);
       setIsWorkspaceLoaded(false);
       setActiveWorkspaceAccount(user.id);
+
+      if (isAccountChange) {
+        clearThreadMessages();
+        setConfig(defaultConfig);
+      }
 
       try {
         const [threads, messages, userSettings, savedConfig] = await Promise.all([
@@ -90,7 +101,9 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
           Object.entries(messages || {}).map(([id, threadMessages]) => [
             id,
             threadMessages.map((message) =>
-              message.metadata.requestState === 'queued' || message.metadata.requestState === 'streaming'
+              isAccountChange &&
+              (message.metadata.requestState === 'queued' ||
+                message.metadata.requestState === 'streaming')
                 ? {
                     ...message,
                     metadata: { ...message.metadata, requestState: 'interrupted' as const },
@@ -107,7 +120,8 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
               )[0];
               const shouldReuseLatest =
                 latestThread?.metadata.nameSource === 'default' &&
-                !storedMessages[latestThread.id]?.length;
+                !(messagesByThreadRef.current[latestThread.id] || storedMessages[latestThread.id])
+                  ?.length;
 
               return shouldReuseLatest
                 ? {
@@ -138,6 +152,7 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
         }
 
         if (cancelled) return;
+        workspaceAccountRef.current = user.id;
         setConfig({ ...defaultConfig, ...savedConfig });
         hydrateThreadMessages(storedMessages);
         setThread(threadData);

--- a/apps/client/app/routes/home.tsx
+++ b/apps/client/app/routes/home.tsx
@@ -13,19 +13,25 @@ import {
   hydrateThreadMessagesAtom,
   replaceMessagesAtom,
   messageSaveEffect,
+  resetChatQueueAtom,
   threadAtom,
   threadMessagesAtom,
+  threadSettingsOpenAtom,
   threadSaveEffect,
+  userSettingsOpenAtom,
+  waitForPersistence,
   workspaceReadyAtom,
 } from '@/store';
 import {
   getConfig,
+  getActiveWorkspaceAccount,
   getMessages,
   getThreads,
   getUserSettings,
   setActiveWorkspaceAccount,
   setThreads,
 } from '@/utils/lforage';
+import { abortAllStreams } from '@/utils/chat-stream-registry';
 import Input from '@/components/Input';
 import Thread from '@/components/Thread';
 import Loading from '@/loading';
@@ -44,9 +50,11 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
   const replaceMessages = useSetAtom(replaceMessagesAtom);
   const messagesByThread = useAtomValue(threadMessagesAtom);
   const setConfig = useSetAtom(configAtom);
+  const resetChatQueue = useSetAtom(resetChatQueueAtom);
+  const setThreadSettingsOpen = useSetAtom(threadSettingsOpenAtom);
+  const setUserSettingsOpen = useSetAtom(userSettingsOpenAtom);
   const setWorkspaceReady = useSetAtom(workspaceReadyAtom);
   const [isWorkspaceLoaded, setIsWorkspaceLoaded] = useState(false);
-  const workspaceAccountRef = useRef<string | null>(null);
   const messagesByThreadRef = useRef(messagesByThread);
 
   messagesByThreadRef.current = messagesByThread;
@@ -62,30 +70,61 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    let cancelled = false;
+
     if (!isLoaded || !isSignedIn || !user?.id) {
-      workspaceAccountRef.current = null;
+      const previousAccountId = getActiveWorkspaceAccount();
       setWorkspaceReady(false);
-      setActiveWorkspaceAccount(null);
+      abortAllStreams();
+      resetChatQueue();
+      setThreadSettingsOpen(false);
+      setUserSettingsOpen(false);
       setConfig(defaultConfig);
       setThread(null);
       clearThreadMessages();
       setIsWorkspaceLoaded(false);
-      return;
+
+      void waitForPersistence().then(
+        () => {
+          if (!cancelled && getActiveWorkspaceAccount() === previousAccountId) {
+            setActiveWorkspaceAccount(null);
+          }
+        },
+        (error) => {
+          console.error('Failed to finish saving the previous workspace', error);
+          if (!cancelled && getActiveWorkspaceAccount() === previousAccountId) {
+            setActiveWorkspaceAccount(null);
+          }
+        }
+      );
+      return () => {
+        cancelled = true;
+      };
     }
 
-    let cancelled = false;
-
     const loadWorkspace = async () => {
-      const isAccountChange = workspaceAccountRef.current !== user.id;
+      const previousAccountId = getActiveWorkspaceAccount();
+      const isAccountChange = previousAccountId !== user.id;
       setWorkspaceReady(false);
       setThread(null);
       setIsWorkspaceLoaded(false);
-      setActiveWorkspaceAccount(user.id);
 
       if (isAccountChange) {
+        abortAllStreams();
+        resetChatQueue();
+        setThreadSettingsOpen(false);
+        setUserSettingsOpen(false);
         clearThreadMessages();
         setConfig(defaultConfig);
+
+        try {
+          await waitForPersistence();
+        } catch (error) {
+          console.error('Failed to finish saving the previous workspace', error);
+        }
+        if (cancelled) return;
       }
+      setActiveWorkspaceAccount(user.id);
 
       try {
         const [threads, messages, userSettings, savedConfig] = await Promise.all([
@@ -101,9 +140,8 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
           Object.entries(messages || {}).map(([id, threadMessages]) => [
             id,
             threadMessages.map((message) =>
-              isAccountChange &&
-              (message.metadata.requestState === 'queued' ||
-                message.metadata.requestState === 'streaming')
+              message.metadata.requestState === 'queued' ||
+              message.metadata.requestState === 'streaming'
                 ? {
                     ...message,
                     metadata: { ...message.metadata, requestState: 'interrupted' as const },
@@ -118,10 +156,13 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
               const latestThread = [...storedThreads].sort(
                 (a, b) => b.metadata.timestamp - a.metadata.timestamp
               )[0];
+              const latestMessages = latestThread
+                ? messagesByThreadRef.current[latestThread.id] ||
+                  storedMessages[latestThread.id] ||
+                  []
+                : [];
               const shouldReuseLatest =
-                latestThread?.metadata.nameSource === 'default' &&
-                !(messagesByThreadRef.current[latestThread.id] || storedMessages[latestThread.id])
-                  ?.length;
+                latestThread?.metadata.nameSource === 'default' && !latestMessages.length;
 
               return shouldReuseLatest
                 ? {
@@ -152,7 +193,6 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
         }
 
         if (cancelled) return;
-        workspaceAccountRef.current = user.id;
         setConfig({ ...defaultConfig, ...savedConfig });
         hydrateThreadMessages(storedMessages);
         setThread(threadData);
@@ -184,8 +224,11 @@ const Home = ({ params: { threadId } }: Route.ComponentProps) => {
     clearThreadMessages,
     hydrateThreadMessages,
     replaceMessages,
+    resetChatQueue,
     setConfig,
     setThread,
+    setThreadSettingsOpen,
+    setUserSettingsOpen,
     setWorkspaceReady,
     threadId,
     user?.id,

--- a/apps/client/app/store/index.tsx
+++ b/apps/client/app/store/index.tsx
@@ -14,7 +14,6 @@ export const editorAtom = atom('');
 
 // Chats
 
-export const threadLoadingAtom = atom(false);
 export const speechPlaybackAtom = atom(false);
 export const userSettingsOpenAtom = atom(false);
 export const threadSettingsOpenAtom = atom(false);
@@ -36,6 +35,8 @@ export interface IMessageCommons {
     responseId?: string;
     responseModelId?: string;
     responseTimestamp?: string;
+    requestId?: string;
+    requestState?: 'queued' | 'streaming' | 'failed' | 'interrupted';
   };
 }
 
@@ -58,27 +59,71 @@ export interface IImageMessage {
 
 export type IMessage = IMessageCommons & (ITextMessage | IImageMessage);
 
-/** The active thread's messages. Mutations go through the action atoms below. */
-export const messagesAtom = atom<IMessage[]>([]);
+export type ThreadId = string;
+
+/** All loaded thread messages. Streams always update this map by thread id. */
+export const threadMessagesAtom = atom<Record<ThreadId, IMessage[]>>({});
+
+/** The selected thread's message view, retained for existing consumers. */
+export const messagesAtom = atom((get) => {
+  const thread = get(threadAtom);
+  return thread ? get(threadMessagesAtom)[thread.id] || [] : [];
+});
 
 /** Replace messages when the active route/thread changes. */
-export const replaceMessagesAtom = atom(null, (_get, set, messages: IMessage[]) => {
-  set(messagesAtom, messages);
+export const replaceMessagesAtom = atom(null, (get, set, messages: IMessage[]) => {
+  const thread = get(threadAtom);
+  if (!thread) return;
+  set(threadMessagesAtom, { ...get(threadMessagesAtom), [thread.id]: messages });
+});
+
+/** Hydrate storage without replacing newer in-memory stream updates. */
+export const hydrateThreadMessagesAtom = atom(
+  null,
+  (get, set, storedMessages: Record<ThreadId, IMessage[]>) => {
+    const current = get(threadMessagesAtom);
+    const next = { ...storedMessages, ...current };
+    set(threadMessagesAtom, next);
+  }
+);
+
+export const clearThreadMessagesAtom = atom(null, (_get, set) => {
+  set(threadMessagesAtom, {});
 });
 
 /** Append a new message, or replace an existing message while it streams. */
 export const upsertMessageAtom = atom(null, (get, set, message: IMessage) => {
-  const messages = get(messagesAtom);
-  const index = messages.findIndex(({ id }) => id === message.id);
+  const thread = get(threadAtom);
+  if (!thread) return;
+  set(upsertThreadMessageAtom, { threadId: thread.id, message });
+});
+
+export const upsertThreadMessageAtom = atom(
+  null,
+  (get, set, update: { threadId: ThreadId; message: IMessage }) => {
+  const messages = get(threadMessagesAtom)[update.threadId] || [];
+  const index = messages.findIndex(({ id }) => id === update.message.id);
 
   if (index === -1) {
-    set(messagesAtom, [...messages, message]);
+      set(threadMessagesAtom, {
+        ...get(threadMessagesAtom),
+        [update.threadId]: [...messages, update.message],
+      });
     return;
   }
 
   const nextMessages = messages.slice();
-  nextMessages[index] = message;
-  set(messagesAtom, nextMessages);
+    nextMessages[index] = update.message;
+    set(threadMessagesAtom, { ...get(threadMessagesAtom), [update.threadId]: nextMessages });
+  }
+);
+
+export const removeThreadMessageAtom = atom(null, (get, set, update: { threadId: ThreadId; id: string }) => {
+  const messages = get(threadMessagesAtom)[update.threadId] || [];
+  set(threadMessagesAtom, {
+    ...get(threadMessagesAtom),
+    [update.threadId]: messages.filter((message) => message.id !== update.id),
+  });
 });
 
 // Base Configuration for all models
@@ -179,7 +224,50 @@ export const getDefaultThread = (
 };
 
 export const threadAtom = atom<IThread<enabledModelsType> | null>(null);
-export const chatAbortControllerAtom = atom<AbortController | null>(null);
+
+export interface ChatJob {
+  id: IMessage['id'];
+  threadId: ThreadId;
+  prompt: string;
+  userMessageId: IMessage['id'];
+  thread: IThread<enabledModelsType>;
+  messages: IMessage[];
+  config: IConfig;
+  createdAt: number;
+}
+
+export const activeChatJobAtom = atom<ChatJob | null>(null);
+export const queuedChatJobsAtom = atom<ChatJob[]>([]);
+export const threadChatErrorsAtom = atom<Record<ThreadId, string>>({});
+
+export const threadChatStateAtom = atom((get) => {
+  const active = get(activeChatJobAtom);
+  const queued = get(queuedChatJobsAtom);
+  const result: Record<ThreadId, { state: 'streaming' | 'queued'; position?: number }> = {};
+
+  if (active) result[active.threadId] = { state: 'streaming' };
+  queued.forEach((job, index) => {
+    result[job.threadId] = { state: 'queued', position: index + 1 };
+  });
+
+  return result;
+});
+
+export const threadLoadingAtom = atom((get) => {
+  const thread = get(threadAtom);
+  return Boolean(thread && get(activeChatJobAtom)?.threadId === thread.id);
+});
+
+export const threadQueuedJobAtom = atom((get) => {
+  const thread = get(threadAtom);
+  return thread ? get(queuedChatJobsAtom).find((job) => job.threadId === thread.id) || null : null;
+});
+
+export const clearThreadChatErrorAtom = atom(null, (get, set, threadId: ThreadId) => {
+  const { [threadId]: _cleared, ...remaining } = get(threadChatErrorsAtom);
+  set(threadChatErrorsAtom, remaining);
+});
+
 export const threadsRefreshAtom = atom(0);
 export const refreshThreadsAtom = atom(null, (_get, set) => {
   set(threadsRefreshAtom, (value) => value + 1);
@@ -238,14 +326,12 @@ export const threadSaveEffect = atomEffect((get, set) => {
 });
 
 export const messageSaveEffect = atomEffect((get, set) => {
-  const thread = get(threadAtom);
-  const messages = get(messagesAtom);
+  const messagesByThread = get(threadMessagesAtom);
   const workspaceReady = get(workspaceReadyAtom);
-  if (!thread || !workspaceReady) return;
+  if (!workspaceReady) return;
 
   void enqueuePersistence(async () => {
-    const allMessages = (await getMessages()) || {};
-    await setMessages({ ...allMessages, [thread.id]: messages });
+    await setMessages(messagesByThread);
   }).catch((err) => console.error('Failed to save messages', err));
 });
 

--- a/apps/client/app/store/index.tsx
+++ b/apps/client/app/store/index.tsx
@@ -101,30 +101,49 @@ export const upsertMessageAtom = atom(null, (get, set, message: IMessage) => {
 export const upsertThreadMessageAtom = atom(
   null,
   (get, set, update: { threadId: ThreadId; message: IMessage }) => {
-  const messages = get(threadMessagesAtom)[update.threadId] || [];
-  const index = messages.findIndex(({ id }) => id === update.message.id);
+    const messages = get(threadMessagesAtom)[update.threadId] || [];
+    const index = messages.findIndex(({ id }) => id === update.message.id);
 
-  if (index === -1) {
+    if (index === -1) {
+      const requestId = update.message.metadata.requestId;
+      const pairedMessageIndex = requestId
+        ? messages.findIndex(
+            (message) =>
+              message.metadata.requestId === requestId && message.role !== update.message.role
+          )
+        : -1;
+      const insertionIndex =
+        pairedMessageIndex === -1
+          ? messages.length
+          : update.message.role === 'user'
+            ? pairedMessageIndex
+            : pairedMessageIndex + 1;
+      const nextMessages = messages.slice();
+      nextMessages.splice(insertionIndex, 0, update.message);
+
       set(threadMessagesAtom, {
         ...get(threadMessagesAtom),
-        [update.threadId]: [...messages, update.message],
+        [update.threadId]: nextMessages,
       });
-    return;
-  }
+      return;
+    }
 
-  const nextMessages = messages.slice();
+    const nextMessages = messages.slice();
     nextMessages[index] = update.message;
     set(threadMessagesAtom, { ...get(threadMessagesAtom), [update.threadId]: nextMessages });
   }
 );
 
-export const removeThreadMessageAtom = atom(null, (get, set, update: { threadId: ThreadId; id: string }) => {
-  const messages = get(threadMessagesAtom)[update.threadId] || [];
-  set(threadMessagesAtom, {
-    ...get(threadMessagesAtom),
-    [update.threadId]: messages.filter((message) => message.id !== update.id),
-  });
-});
+export const removeThreadMessageAtom = atom(
+  null,
+  (get, set, update: { threadId: ThreadId; id: string }) => {
+    const messages = get(threadMessagesAtom)[update.threadId] || [];
+    set(threadMessagesAtom, {
+      ...get(threadMessagesAtom),
+      [update.threadId]: messages.filter((message) => message.id !== update.id),
+    });
+  }
+);
 
 // Base Configuration for all models
 export interface IBaseModelConfig {
@@ -230,6 +249,7 @@ export interface ChatJob {
   threadId: ThreadId;
   prompt: string;
   userMessageId: IMessage['id'];
+  assistantMessageId: IMessage['id'];
   thread: IThread<enabledModelsType>;
   messages: IMessage[];
   config: IConfig;

--- a/apps/client/app/store/index.tsx
+++ b/apps/client/app/store/index.tsx
@@ -91,6 +91,14 @@ export const clearThreadMessagesAtom = atom(null, (_get, set) => {
   set(threadMessagesAtom, {});
 });
 
+export const removeThreadMessagesAtom = atom(null, (get, set, threadId: ThreadId) => {
+  const current = get(threadMessagesAtom);
+  if (!(threadId in current)) return;
+
+  const { [threadId]: _removed, ...remaining } = current;
+  set(threadMessagesAtom, remaining);
+});
+
 /** Append a new message, or replace an existing message while it streams. */
 export const upsertMessageAtom = atom(null, (get, set, message: IMessage) => {
   const thread = get(threadAtom);
@@ -246,6 +254,7 @@ export const threadAtom = atom<IThread<enabledModelsType> | null>(null);
 
 export interface ChatJob {
   id: IMessage['id'];
+  accountId: string;
   threadId: ThreadId;
   prompt: string;
   userMessageId: IMessage['id'];
@@ -260,6 +269,89 @@ export const activeChatJobAtom = atom<ChatJob | null>(null);
 export const queuedChatJobsAtom = atom<ChatJob[]>([]);
 export const threadChatErrorsAtom = atom<Record<ThreadId, string>>({});
 
+export const enqueueChatJobAtom = atom(null, (get, set, job: ChatJob) => {
+  const activeJob = get(activeChatJobAtom);
+  const queuedJobs = get(queuedChatJobsAtom);
+
+  if (
+    activeJob?.threadId === job.threadId ||
+    queuedJobs.some((queuedJob) => queuedJob.threadId === job.threadId)
+  ) {
+    return false;
+  }
+
+  set(upsertThreadMessageAtom, {
+    threadId: job.threadId,
+    message: {
+      id: job.userMessageId,
+      role: 'user',
+      content: job.prompt,
+      metadata: {
+        model: job.thread.settings.model,
+        profile: null,
+        timestamp: job.createdAt,
+        requestId: job.id,
+        requestState: activeJob || queuedJobs.length ? 'queued' : 'streaming',
+      },
+      type: 'text',
+    },
+  });
+  set(queuedChatJobsAtom, [...queuedJobs, job]);
+  return true;
+});
+
+export const cancelQueuedChatJobAtom = atom(null, (get, set, threadId: ThreadId) => {
+  const queuedJobs = get(queuedChatJobsAtom);
+  const job = queuedJobs.find((queuedJob) => queuedJob.threadId === threadId);
+  if (!job) return null;
+
+  set(
+    queuedChatJobsAtom,
+    queuedJobs.filter((queuedJob) => queuedJob.id !== job.id)
+  );
+  set(removeThreadMessageAtom, { threadId, id: job.userMessageId });
+  return job.prompt;
+});
+
+export const dequeueNextChatJobAtom = atom(null, (get, set) => {
+  if (get(activeChatJobAtom)) return;
+
+  const [nextJob, ...remainingJobs] = get(queuedChatJobsAtom);
+  if (!nextJob) return;
+
+  set(queuedChatJobsAtom, remainingJobs);
+  set(activeChatJobAtom, nextJob);
+});
+
+export const resetChatQueueAtom = atom(null, (get, set) => {
+  const currentMessages = get(threadMessagesAtom);
+  let didInterruptMessage = false;
+  const interruptedMessages = Object.fromEntries(
+    Object.entries(currentMessages).map(([threadId, messages]) => [
+      threadId,
+      messages.map((message) => {
+        if (
+          message.metadata.requestState !== 'queued' &&
+          message.metadata.requestState !== 'streaming'
+        ) {
+          return message;
+        }
+
+        didInterruptMessage = true;
+        return {
+          ...message,
+          metadata: { ...message.metadata, requestState: 'interrupted' as const },
+        };
+      }),
+    ])
+  );
+
+  if (didInterruptMessage) set(threadMessagesAtom, interruptedMessages);
+  set(activeChatJobAtom, null);
+  set(queuedChatJobsAtom, []);
+  set(threadChatErrorsAtom, {});
+});
+
 export const threadChatStateAtom = atom((get) => {
   const active = get(activeChatJobAtom);
   const queued = get(queuedChatJobsAtom);
@@ -267,7 +359,9 @@ export const threadChatStateAtom = atom((get) => {
 
   if (active) result[active.threadId] = { state: 'streaming' };
   queued.forEach((job, index) => {
-    result[job.threadId] = { state: 'queued', position: index + 1 };
+    if (!result[job.threadId]) {
+      result[job.threadId] = { state: 'queued', position: index + 1 };
+    }
   });
 
   return result;

--- a/apps/client/app/utils/chat-stream-registry.ts
+++ b/apps/client/app/utils/chat-stream-registry.ts
@@ -1,0 +1,20 @@
+import type { ThreadId } from '@/store';
+
+let active: { threadId: ThreadId; controller: AbortController } | null = null;
+
+export const registerActiveStream = (threadId: ThreadId, controller: AbortController) => {
+  active = { threadId, controller };
+};
+
+export const clearActiveStream = (controller: AbortController) => {
+  if (active?.controller === controller) active = null;
+};
+
+export const abortThreadStream = (threadId: ThreadId) => {
+  if (active?.threadId === threadId) active.controller.abort();
+};
+
+export const abortAllStreams = () => {
+  active?.controller.abort();
+  active = null;
+};

--- a/apps/client/app/utils/chat-stream-registry.ts
+++ b/apps/client/app/utils/chat-stream-registry.ts
@@ -1,6 +1,7 @@
 import type { ThreadId } from '@/store';
 
 let active: { threadId: ThreadId; controller: AbortController } | null = null;
+const discardedSignals = new WeakSet<AbortSignal>();
 
 export const registerActiveStream = (threadId: ThreadId, controller: AbortController) => {
   active = { threadId, controller };
@@ -15,6 +16,12 @@ export const abortThreadStream = (threadId: ThreadId) => {
 };
 
 export const abortAllStreams = () => {
-  active?.controller.abort();
+  if (active) {
+    discardedSignals.add(active.controller.signal);
+    active.controller.abort();
+  }
   active = null;
 };
+
+export const isDiscardedStream = (signal?: AbortSignal) =>
+  Boolean(signal && discardedSignals.has(signal));

--- a/apps/client/app/utils/lforage.ts
+++ b/apps/client/app/utils/lforage.ts
@@ -26,6 +26,8 @@ export const setActiveWorkspaceAccount = (accountId: string | null) => {
   activeWorkspaceAccount = accountId;
 };
 
+export const getActiveWorkspaceAccount = () => activeWorkspaceAccount;
+
 export const getConfig = async (): Promise<IConfig | null> => {
   const key = scopedKey(settingsKey);
   return key ? ((await lforage.getItem(key)) as IConfig | null) : null;


### PR DESCRIPTION
## Summary
- support one active streamed response while prompts in other threads wait in FIFO order
- keep streams updating their owning thread across navigation and settings dialogs
- show streaming, queued, and background failure state in the sidebar
- restore cancelled queued prompts to the composer