### PR TITLE
feat: discover BYOK provider models

### DIFF
--- a/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
+++ b/apps/client/app/components/AppSidebar/UserSettingsDialog.tsx
@@ -17,7 +17,7 @@ import { useTheme } from 'next-themes';
 import { toast } from 'sonner';
 
 import type { enabledModelsType } from 'utils';
-import { languages, supportedTextModels, profiles } from 'utils';
+import { defaultModel, languages, profiles } from 'utils';
 
 import {
   configAtom,
@@ -75,6 +75,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useByokModelAvailability } from '@/hooks/useByokModelAvailability';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -129,6 +130,8 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
   const updateActiveThreadSettings = useSetAtom(updateThreadSettingsAtom);
   const customInstructionsRef = useRef<HTMLElement>(null);
   const byokRef = useRef<HTMLElement>(null);
+  const { textModels, findModel, isModelAvailable, isProviderAvailable } =
+    useByokModelAvailability();
 
   useEffect(() => {
     if (!open || !scrollTarget) return;
@@ -312,11 +315,37 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
     };
   }, [config.customInstructions, open]);
 
+  useEffect(() => {
+    const currentModel = findModel(threadSettings.model);
+    const modelProviderAvailable = threadSettings.modelProvider
+      ? isProviderAvailable(threadSettings.modelProvider)
+      : false;
+    if (
+      isLoading ||
+      (currentModel && isModelAvailable(currentModel)) ||
+      (!currentModel && (!threadSettings.modelProvider || modelProviderAvailable))
+    ) {
+      return;
+    }
+
+    const nextSettings: IThreadSettings<enabledModelsType> = {
+      ...threadSettings,
+      model: defaultModel,
+    };
+    setThreadSettings(nextSettings);
+    void setUserSettings(nextSettings).catch((error) => {
+      console.error('Failed to restore an available default model', error);
+    });
+  }, [findModel, isLoading, isModelAvailable, isProviderAvailable, threadSettings]);
+
   const updateThreadSetting = async <K extends keyof IThreadSettings<enabledModelsType>>(
     key: K,
     value: IThreadSettings<enabledModelsType>[K]
   ) => {
     const nextSettings = { ...threadSettings, [key]: value };
+    if (key === 'model') {
+      nextSettings.modelProvider = findModel(String(value))?.provider;
+    }
     setThreadSettings(nextSettings);
     try {
       await setUserSettings(nextSettings);
@@ -604,9 +633,12 @@ const UserSettingsDialog = ({ open, onOpenChange }: UserSettingsDialogProps) => 
                   <SelectValue placeholder="Model" />
                 </SelectTrigger>
                 <SelectContent>
-                  {supportedTextModels.map(({ name, text, disabled }) => (
-                    <SelectItem key={name} value={name} disabled={disabled}>
-                      {text}
+                  {textModels.map((modelDefinition) => (
+                    <SelectItem
+                      key={modelDefinition.name}
+                      value={modelDefinition.name}
+                      disabled={!isModelAvailable(modelDefinition)}>
+                      {modelDefinition.text}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/client/app/components/Nav/SettingsDropdown.tsx
+++ b/apps/client/app/components/Nav/SettingsDropdown.tsx
@@ -5,9 +5,7 @@ import { SlidersHorizontal } from 'lucide-react';
 import {
   defaultModel,
   profiles,
-  supportedImageModels,
   imageSizes,
-  supportedTextModels,
 } from 'utils';
 
 import {
@@ -20,6 +18,7 @@ import {
   type UserSettingsScrollTarget,
 } from '@/store';
 import { IS_SPEECH_SYNTHESIS_SUPPORTED } from '@/utils';
+import { useByokModelAvailability } from '@/hooks/useByokModelAvailability';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -46,6 +45,7 @@ const SettingsDropdown = () => {
   const [isThreadSettingsOpen, setThreadSettingsOpen] = useAtom(threadSettingsOpenAtom);
   const setUserSettingsOpen = useSetAtom(userSettingsOpenAtom);
   const setUserSettingsScrollTarget = useSetAtom(userSettingsScrollTargetAtom);
+  const { textModels, imageModels, findModel, isModelAvailable } = useByokModelAvailability();
   const [pendingUserSettingsTarget, setPendingUserSettingsTarget] =
     useState<UserSettingsScrollTarget | null>(null);
 
@@ -82,12 +82,15 @@ const SettingsDropdown = () => {
       if (!thread) return null;
 
       if (name === 'model' || name === 'profile') {
-        updateThreadSettings({ [name]: value } as Parameters<typeof updateThreadSettings>[0]);
+        updateThreadSettings({
+          [name]: value,
+          ...(name === 'model' ? { modelProvider: findModel(value)?.provider } : {}),
+        } as Parameters<typeof updateThreadSettings>[0]);
       } else {
         setConfig({ ...config, [name]: value } as typeof config);
       }
     },
-    [config, setConfig, thread, updateThreadSettings]
+    [config, findModel, setConfig, thread, updateThreadSettings]
   );
 
   const updateCheckSetting = useCallback(
@@ -133,8 +136,8 @@ const SettingsDropdown = () => {
       showDetailedUsage,
     },
   } = thread!;
-  const hasImageModels = supportedImageModels.length;
-  const isImageModelSelected = supportedImageModels.map(({ name }) => name).includes(model);
+  const hasImageModels = imageModels.length;
+  const isImageModelSelected = imageModels.some(({ name }) => name === model);
   const isDallE3Selected = model === 'dall-e-3';
 
   return (
@@ -175,19 +178,22 @@ const SettingsDropdown = () => {
                 <SelectContent>
                   <SelectGroup>
                     <SelectLabel className="text-muted-foreground">Text</SelectLabel>
-                    {supportedTextModels.map(
-                      ({ name, text, isSpecial, isExperimental, disabled }) => (
-                        <SelectItem key={name} value={name} disabled={disabled}>
+                    {textModels.map(
+                      (modelDefinition) => (
+                        <SelectItem
+                          key={modelDefinition.name}
+                          value={modelDefinition.name}
+                          disabled={!isModelAvailable(modelDefinition)}>
                           <div className="flex items-center gap-2">
-                            {text}
-                            {isSpecial && (
+                            {modelDefinition.text}
+                            {modelDefinition.isSpecial && (
                               <Badge
                                 variant="outline"
                                 className="bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-900/20 dark:to-teal-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800">
                                 Special
                               </Badge>
                             )}
-                            {isExperimental && (
+                            {modelDefinition.isExperimental && (
                               <Badge
                                 variant="outline"
                                 className="bg-gradient-to-r from-purple-50 to-fuchsia-50 dark:from-purple-900/20 dark:to-fuchsia-900/20 text-purple-700 dark:text-purple-300 border-purple-200 dark:border-purple-800">
@@ -202,19 +208,23 @@ const SettingsDropdown = () => {
                   {hasImageModels ? (
                     <SelectGroup>
                       <SelectLabel className="text-muted-foreground">Image</SelectLabel>
-                      {supportedImageModels.map(
-                        ({ name, text, isSpecial, isExperimental, disabled }) => (
-                          <SelectItem key={name} value={name} disabled={disabled} className="gap-2">
+                      {imageModels.map(
+                        (modelDefinition) => (
+                          <SelectItem
+                            key={modelDefinition.name}
+                            value={modelDefinition.name}
+                            disabled={!isModelAvailable(modelDefinition)}
+                            className="gap-2">
                             <div className="flex items-center gap-2">
-                              {text}
-                              {isSpecial && (
+                              {modelDefinition.text}
+                              {modelDefinition.isSpecial && (
                                 <Badge
                                   variant="outline"
                                   className="bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-900/20 dark:to-teal-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800">
                                   Special
                                 </Badge>
                               )}
-                              {isExperimental && (
+                              {modelDefinition.isExperimental && (
                                 <Badge
                                   variant="outline"
                                   className="bg-gradient-to-r from-purple-50 to-fuchsia-50 dark:from-purple-900/20 dark:to-fuchsia-900/20 text-purple-700 dark:text-purple-300 border-purple-200 dark:border-purple-800">

--- a/apps/client/app/hooks/useByokModelAvailability.ts
+++ b/apps/client/app/hooks/useByokModelAvailability.ts
@@ -81,8 +81,8 @@ const parseModels = (
       if (
         capabilities &&
         typeof capabilities === 'object' &&
-        'completion' in capabilities &&
-        capabilities.completion !== true
+        'completion_chat' in capabilities &&
+        capabilities.completion_chat !== true
       ) {
         return [];
       }

--- a/apps/client/app/hooks/useByokModelAvailability.ts
+++ b/apps/client/app/hooks/useByokModelAvailability.ts
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useUser } from '@clerk/react-router';
+
+import { supportedModels, type SupportedModel, type modelProviderType } from 'utils';
+
+import {
+  getProviderKey,
+  getVaultSnapshot,
+  subscribeVault,
+  type ByokProvider,
+} from '@/utils/byok-vault';
+
+export type ModelOption = Omit<SupportedModel, 'name' | 'disabled'> & {
+  name: string;
+  disabled: boolean;
+  isDiscovered?: boolean;
+};
+
+interface ProviderModelResponse {
+  data?: Array<Record<string, unknown>>;
+  models?: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+}
+
+const providerEndpoints: Record<ByokProvider, string> = {
+  google: 'https://generativelanguage.googleapis.com/v1beta/models',
+  openai: 'https://api.openai.com/v1/models',
+  anthropic: 'https://api.anthropic.com/v1/models',
+  mistral: 'https://api.mistral.ai/v1/models',
+  deepseek: 'https://api.deepseek.com/models',
+};
+
+const getString = (value: unknown) => (typeof value === 'string' ? value : undefined);
+
+const displayName = (modelId: string) =>
+  modelId
+    .replace(/^models\//, '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+
+const toModelOption = (
+  provider: modelProviderType,
+  modelId: string,
+  label?: string
+): ModelOption => ({
+  name: modelId,
+  text: label || displayName(modelId),
+  type: 'text',
+  disabled: false,
+  provider,
+  isDiscovered: true,
+});
+
+const isOpenAITextModel = (modelId: string) =>
+  !/(embedding|moderation|tts|whisper|transcri|realtime|audio|dall-e|image|search)/i.test(modelId);
+
+const parseModels = (
+  provider: ByokProvider,
+  response: ProviderModelResponse
+): ModelOption[] => {
+  const entries = response.data || response.models || [];
+
+  return entries.flatMap((entry) => {
+    const rawId = getString(entry.id) || getString(entry.name);
+    if (!rawId) return [];
+
+    if (provider === 'google') {
+      const modelId = rawId.replace(/^models\//, '');
+      const actions = Array.isArray(entry.supportedGenerationMethods)
+        ? entry.supportedGenerationMethods
+        : Array.isArray(entry.supportedActions)
+          ? entry.supportedActions
+          : [];
+      if (actions.length && !actions.includes('generateContent')) return [];
+      return [toModelOption(provider, modelId, getString(entry.displayName))];
+    }
+
+    if (provider === 'openai' && !isOpenAITextModel(rawId)) return [];
+    if (provider === 'mistral') {
+      const capabilities = entry.capabilities;
+      if (
+        capabilities &&
+        typeof capabilities === 'object' &&
+        'completion' in capabilities &&
+        capabilities.completion !== true
+      ) {
+        return [];
+      }
+    }
+
+    return [
+      toModelOption(provider, rawId, getString(entry.display_name) || getString(entry.name)),
+    ];
+  });
+};
+
+const fetchProviderModels = async (
+  provider: ByokProvider,
+  apiKey: string,
+  signal: AbortSignal
+) => {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  let endpoint = providerEndpoints[provider];
+
+  if (provider === 'google') {
+    headers['x-goog-api-key'] = apiKey;
+    endpoint += '?pageSize=1000';
+  } else if (provider === 'anthropic') {
+    headers['x-api-key'] = apiKey;
+    headers['anthropic-version'] = '2023-06-01';
+  } else {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const models: ModelOption[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const pageEndpoint = pageToken
+      ? `${endpoint}&pageToken=${encodeURIComponent(pageToken)}`
+      : endpoint;
+    const response = await fetch(pageEndpoint, { headers, signal });
+    if (!response.ok) throw new Error(`Could not list ${provider} models`);
+    const page = (await response.json()) as ProviderModelResponse;
+    models.push(...parseModels(provider, page));
+    pageToken = provider === 'google' ? page.nextPageToken : undefined;
+  } while (pageToken);
+
+  return models;
+};
+
+const catalogOptions = supportedModels.map((model) => ({ ...model })) as ModelOption[];
+
+export const useByokModelAvailability = () => {
+  const { user } = useUser();
+  const [vaultVersion, setVaultVersion] = useState(0);
+  const [discoveredModels, setDiscoveredModels] = useState<ModelOption[]>([]);
+
+  useEffect(() => subscribeVault(() => setVaultVersion((version) => version + 1)), []);
+
+  useEffect(() => {
+    const accountId = user?.id;
+    if (!accountId) {
+      setDiscoveredModels([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const providers = getVaultSnapshot(accountId).providers as ByokProvider[];
+
+    setDiscoveredModels([]);
+    void Promise.all(
+      providers.flatMap((provider) => {
+        const apiKey = getProviderKey(accountId, provider);
+        return apiKey
+          ? fetchProviderModels(provider, apiKey, controller.signal).catch(() => [])
+          : [];
+      })
+    ).then((results) => {
+      if (!controller.signal.aborted) setDiscoveredModels(results.flat());
+    });
+
+    return () => controller.abort();
+  }, [user?.id, vaultVersion]);
+
+  const models = useMemo(() => {
+    const catalogNames = new Set(catalogOptions.map(({ name }) => name));
+    return [...catalogOptions, ...discoveredModels.filter(({ name }) => !catalogNames.has(name))];
+  }, [discoveredModels]);
+
+  const isModelAvailable = useCallback(
+    (model: ModelOption) =>
+      Boolean(user?.id && getProviderKey(user.id, model.provider)) ||
+      (!model.isDiscovered && !model.disabled),
+    [user?.id, vaultVersion]
+  );
+
+  const isProviderAvailable = useCallback(
+    (provider: modelProviderType) => Boolean(user?.id && getProviderKey(user.id, provider)),
+    [user?.id, vaultVersion]
+  );
+
+  const findModel = useCallback(
+    (modelName: string) => models.find(({ name }) => name === modelName),
+    [models]
+  );
+
+  return {
+    models,
+    textModels: models.filter(({ type }) => type === 'text'),
+    imageModels: models.filter(({ type }) => type === 'image'),
+    findModel,
+    isModelAvailable,
+    isProviderAvailable,
+  };
+};

--- a/apps/client/app/hooks/useHandleChatResponse.tsx
+++ b/apps/client/app/hooks/useHandleChatResponse.tsx
@@ -118,7 +118,7 @@ const useHandleChatResponse = () => {
     try {
       if (user?.id !== job.accountId) return { status: 'discarded' as const };
 
-      const provider = providerForModel(thread.settings.model);
+      const provider = providerForModel(thread.settings.model, thread.settings.modelProvider);
       const apiKey = user?.id ? getProviderKey(user.id, provider) : undefined;
       isSharedApiRequest = !apiKey;
       const hasConfiguredProvider = user?.id
@@ -134,6 +134,7 @@ const useHandleChatResponse = () => {
         const imageResponse = await getGeneratedImage({
           prompt,
           model: thread.settings.model,
+          provider,
           size: imageSize,
           quality,
           style,
@@ -191,6 +192,7 @@ const useHandleChatResponse = () => {
             }
             : { prompt }),
           model: thread.settings.model,
+          provider,
           profile: thread.settings.profile,
           language,
           customInstructions: thread.settings.profile === 'custom' ? customInstructions : undefined,

--- a/apps/client/app/store/index.tsx
+++ b/apps/client/app/store/index.tsx
@@ -2,7 +2,13 @@ import { atom } from 'jotai';
 import { atomEffect } from 'jotai-effect';
 import { getTime, format } from 'date-fns';
 
-import type { profilesType, supportedLanguagesType, enabledModelsType, ImageSizeType } from 'utils';
+import type {
+  profilesType,
+  supportedLanguagesType,
+  enabledModelsType,
+  ImageSizeType,
+  modelProviderType,
+} from 'utils';
 
 import { defaultModel } from 'utils';
 
@@ -189,6 +195,7 @@ export type ConversationContextMode = 'single-turn' | 'multi-turn';
 // Thread Settings interface
 export interface IThreadSettings<T extends enabledModelsType> {
   model: T;
+  modelProvider?: modelProviderType;
   profile: profilesType;
   conversationContextMode: ConversationContextMode;
   isTextToSpeechEnabled: boolean;

--- a/apps/client/app/utils/api-calls.ts
+++ b/apps/client/app/utils/api-calls.ts
@@ -1,7 +1,13 @@
 import axios from 'axios';
 import { useAuth } from '@clerk/react-router';
 
-import { chatRequestSchema, enabledModelsType, imageRequestSchema, profilesType } from 'utils';
+import {
+  chatRequestSchema,
+  enabledModelsType,
+  imageRequestSchema,
+  profilesType,
+  type modelProviderType,
+} from 'utils';
 
 import { IConfig } from '@/store/index';
 import { generateByokImage, streamByokText } from './byok-providers';
@@ -58,6 +64,7 @@ export type ChatStreamPart =
 
 interface IGetGeneratedTextBase {
   model: enabledModelsType;
+  provider?: modelProviderType;
   profile: profilesType;
   customInstructions?: string;
   language?: string;
@@ -87,6 +94,7 @@ export const getGeneratedText = async ({
   prompt,
   messages,
   model,
+  provider,
   profile,
   language,
   getToken,
@@ -94,14 +102,17 @@ export const getGeneratedText = async ({
   customInstructions,
   signal,
 }: IGetGeneratedText): Promise<ReadableStream<ChatStreamPart> | ErrorType> => {
-  const requestBody = chatRequestSchema.safeParse({
+  const requestPayload = {
     prompt,
     messages,
     language,
     profile,
     model,
     customInstructions,
-  });
+  };
+  const requestBody = apiKey
+    ? { success: true as const, data: requestPayload }
+    : chatRequestSchema.safeParse(requestPayload);
   if (!requestBody.success) {
     return { success: false, err: 'Invalid chat request.' };
   }
@@ -109,6 +120,7 @@ export const getGeneratedText = async ({
     try {
       return await streamByokText({
         model,
+        provider,
         profile,
         customInstructions,
         language: (language || 'en-US') as Parameters<typeof streamByokText>[0]['language'],
@@ -186,6 +198,7 @@ export const getGeneratedText = async ({
 interface IGetGeneratedImage {
   prompt: string;
   model: enabledModelsType;
+  provider?: modelProviderType;
   quality: IConfig['quality'];
   style: IConfig['style'];
   size?: string;
@@ -201,6 +214,7 @@ interface GeneratedImageResponse {
 export const getGeneratedImage = async ({
   prompt,
   model,
+  provider,
   quality,
   style,
   size,
@@ -214,7 +228,16 @@ export const getGeneratedImage = async ({
   }
   if (apiKey) {
     try {
-      return await generateByokImage({ prompt, model, quality, style, size, apiKey, signal });
+      return await generateByokImage({
+        prompt,
+        model,
+        provider,
+        quality,
+        style,
+        size,
+        apiKey,
+        signal,
+      });
     } catch {
       return {
         success: false,

--- a/apps/client/app/utils/byok-providers.ts
+++ b/apps/client/app/utils/byok-providers.ts
@@ -5,11 +5,20 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createMistral } from '@ai-sdk/mistral';
 import { createOpenAI } from '@ai-sdk/openai';
 
-import { getAssistantConfig, supportedModels, type availableModelsType } from 'utils';
+import {
+  getAssistantConfig,
+  supportedModels,
+  type availableModelsType,
+  type modelProviderType,
+} from 'utils';
 import type { ByokProvider } from './byok-vault';
 import type { ChatResponseMetadata, ChatStreamPart } from './api-calls';
 
-export const providerForModel = (model: availableModelsType): ByokProvider => {
+export const providerForModel = (
+  model: availableModelsType,
+  explicitProvider?: modelProviderType
+): ByokProvider => {
+  if (explicitProvider) return explicitProvider;
   const definition = supportedModels.find((entry) => entry.name === model);
   if (!definition) throw new Error(`Unsupported model: ${model}`);
   return definition.provider;
@@ -30,17 +39,18 @@ const createProvider = (provider: ByokProvider, apiKey: string) => {
   }
 };
 
-const modelInstance = (model: availableModelsType, apiKey: string) => {
-  const provider = createProvider(providerForModel(model), apiKey) as any;
-  return model.startsWith('gpt') || model.startsWith('claude') || model.startsWith('deepseek')
-    ? provider.chat(model)
-    : model.startsWith('mistral') || model.startsWith('gemini')
-      ? provider.chat(model)
-      : provider.languageModel(model);
+const modelInstance = (
+  model: availableModelsType,
+  apiKey: string,
+  explicitProvider?: modelProviderType
+) => {
+  const provider = createProvider(providerForModel(model, explicitProvider), apiKey) as any;
+  return provider.chat(model);
 };
 
 export const streamByokText = async ({
   model,
+  provider,
   apiKey,
   profile,
   language,
@@ -50,6 +60,7 @@ export const streamByokText = async ({
   signal,
 }: {
   model: availableModelsType;
+  provider?: modelProviderType;
   apiKey: string;
   profile: Parameters<typeof getAssistantConfig>[0];
   language: Parameters<typeof getAssistantConfig>[1];
@@ -60,7 +71,7 @@ export const streamByokText = async ({
 }): Promise<ReadableStream<ChatStreamPart>> => {
   const config = getAssistantConfig(profile, language, customInstructions);
   const result = streamText({
-    model: modelInstance(model, apiKey),
+    model: modelInstance(model, apiKey, provider),
     instructions: config.prompt,
     messages: messages || [{ role: 'user', content: prompt || '' }],
     temperature: config.temperature,
@@ -130,6 +141,7 @@ export const streamByokText = async ({
 
 export const generateByokImage = async ({
   model,
+  provider,
   apiKey,
   prompt,
   quality,
@@ -138,6 +150,7 @@ export const generateByokImage = async ({
   signal,
 }: {
   model: availableModelsType;
+  provider?: modelProviderType;
   apiKey: string;
   prompt: string;
   quality: 'standard' | 'hd';
@@ -145,9 +158,9 @@ export const generateByokImage = async ({
   size?: string;
   signal?: AbortSignal;
 }) => {
-  const provider = createProvider(providerForModel(model), apiKey) as any;
+  const providerClient = createProvider(providerForModel(model, provider), apiKey) as any;
   const result = await generateImage({
-    model: provider.imageModel(model),
+    model: providerClient.imageModel(model),
     prompt,
     n: 1,
     size: size as `${number}x${number}` | undefined,

--- a/apps/client/app/utils/byok-vault.ts
+++ b/apps/client/app/utils/byok-vault.ts
@@ -1,6 +1,8 @@
 import localforage from 'localforage';
 
-export type ByokProvider = 'google' | 'openai' | 'anthropic' | 'mistral' | 'deepseek';
+import type { modelProviderType } from 'utils';
+
+export type ByokProvider = modelProviderType;
 
 export type ProviderKeys = Partial<Record<ByokProvider, string>>;
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,21 +2,21 @@
   "name": "utils",
   "main": "index.ts",
   "peerDependencies": {
-    "@ai-sdk/anthropic": "^4.0.39",
-    "@ai-sdk/deepseek": "^3.0.28",
-    "@ai-sdk/google": "^4.0.45",
-    "@ai-sdk/mistral": "^4.0.29",
-    "@ai-sdk/openai": "^4.0.42",
-    "ai": "^7.0.67",
+    "@ai-sdk/anthropic": "^4.0.47",
+    "@ai-sdk/deepseek": "^3.0.38",
+    "@ai-sdk/google": "^4.0.61",
+    "@ai-sdk/mistral": "^4.0.38",
+    "@ai-sdk/openai": "^4.0.55",
+    "ai": "^7.0.89",
     "zod": "^3.24.0 || ^4.0.0"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^4.0.39",
-    "@ai-sdk/deepseek": "^3.0.28",
-    "@ai-sdk/google": "^4.0.45",
-    "@ai-sdk/mistral": "^4.0.29",
-    "@ai-sdk/openai": "^4.0.42",
-    "ai": "^7.0.67",
+    "@ai-sdk/anthropic": "^4.0.47",
+    "@ai-sdk/deepseek": "^3.0.38",
+    "@ai-sdk/google": "^4.0.61",
+    "@ai-sdk/mistral": "^4.0.38",
+    "@ai-sdk/openai": "^4.0.55",
+    "ai": "^7.0.89",
     "typescript": "^7.0.2",
     "zod": "^4.4.3"
   }

--- a/packages/utils/src/models.ts
+++ b/packages/utils/src/models.ts
@@ -1,6 +1,6 @@
 import { ToolChoice, ToolSet } from 'ai';
 
-import { availableModelsType, supportedLanguagesType, profilesType } from './types';
+import { availableModelsType, modelProviderType, supportedLanguagesType, profilesType } from './types';
 
 export type SupportedModel = {
   name: availableModelsType;
@@ -9,7 +9,7 @@ export type SupportedModel = {
   disabled: boolean;
   isSpecial?: boolean;
   isExperimental?: boolean;
-  provider: 'google' | 'openai' | 'anthropic' | 'mistral' | 'deepseek';
+  provider: modelProviderType;
 };
 
 export const supportedModels = [

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -7,7 +7,11 @@ import { DeepSeekProvider } from '@ai-sdk/deepseek';
 import { profiles, supportedModels } from './models';
 import { languages } from './languages';
 
-export type enabledModelsType = (typeof supportedModels)[number]['name'];
+// The curated catalog remains literal-friendly, while BYOK model discovery may
+// return provider model IDs that are not known at build time.
+export type enabledModelsType = (typeof supportedModels)[number]['name'] | (string & {});
+
+export type modelProviderType = 'google' | 'openai' | 'anthropic' | 'mistral' | 'deepseek';
 
 export type availableModelsType =
   | Parameters<GoogleGenerativeAIProvider['chat']>[0]
@@ -15,6 +19,7 @@ export type availableModelsType =
   | Parameters<AnthropicProvider['languageModel']>[0]
   | Parameters<MistralProvider['chat']>[0]
   | Parameters<DeepSeekProvider['languageModel']>[0]
+  | (string & {});
 
 export type supportedLanguagesType = (typeof languages)[number]['code'];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,23 +362,23 @@ importers:
   packages/utils:
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^4.0.39
-        version: 4.0.39(zod@4.4.3)
+        specifier: ^4.0.47
+        version: 4.0.47(zod@4.5.4)
       '@ai-sdk/deepseek':
-        specifier: ^3.0.28
-        version: 3.0.28(zod@4.4.3)
+        specifier: ^3.0.38
+        version: 3.0.38(zod@4.5.4)
       '@ai-sdk/google':
-        specifier: ^4.0.45
-        version: 4.0.45(zod@4.4.3)
+        specifier: ^4.0.61
+        version: 4.0.61(zod@4.5.4)
       '@ai-sdk/mistral':
-        specifier: ^4.0.29
-        version: 4.0.29(zod@4.4.3)
+        specifier: ^4.0.38
+        version: 4.0.38(zod@4.5.4)
       '@ai-sdk/openai':
-        specifier: ^4.0.42
-        version: 4.0.42(zod@4.4.3)
+        specifier: ^4.0.55
+        version: 4.0.55(zod@4.5.4)
       ai:
-        specifier: ^7.0.67
-        version: 7.0.67(zod@4.4.3)
+        specifier: ^7.0.89
+        version: 7.0.89(zod@4.5.4)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
## What changed

BYOK users can now select the provider models available to their own API key. The model picker is no longer limited to PolyChat's curated catalog for a provider with an active key.

## User behavior

- Entering or unlocking a provider key discovers that provider's chat-capable models.
- Discovered models appear in Thread settings and Settings > New thread defaults.
- Google, OpenAI, Anthropic, Mistral, and DeepSeek are supported.
- Other providers and models continue to follow the curated supportedModels enabled/disabled rules.
- Saving a model also saves its provider, so dynamically discovered IDs route through the correct BYOK client.
- Locking, removing, or resetting a key removes its discovered models immediately.
- Shared server requests still use the existing catalog validation and are not expanded by BYOK discovery.

## Implementation details

- Added reactive provider model discovery using each provider's authenticated model-list endpoint.
- Added Google pagination support.
- Filtered provider entries that cannot be used by PolyChat's text chat flow, such as embeddings, moderation, audio, and image-only models.
- Extended model typing to support provider IDs that are only known at runtime.
- Persisted the selected provider with dynamic model IDs.
- Aligned `packages/utils` AI SDK and Zod versions with client and serverless to prevent duplicate `provider-utils` types.
- Preserved the existing encrypted vault and session-key behavior.

## Validation

- Client TypeScript check passed
- Utils TypeScript check passed
- Client production build passed
- `git diff --check` passed
- `graphify update .` completed

## Notes

The local pnpm install could not refresh because pnpm project-version signature verification failed before installation. The tracked package manifests and lockfile are aligned, and a clean install should use the matching dependency tree.